### PR TITLE
[Refactor] #193 actor도입과 메모리 누수 해결

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Cache/CachedImage.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Cache/CachedImage.swift
@@ -17,10 +17,11 @@ struct CachedImage<Placeholder: View>: View {
     }
     
     var body: some View {
-        content
-            .onAppear(perform: loader.load)
-            .onDisappear(perform: loader.cancel)
-    }
+            content
+                .task {
+                    await loader.load()
+                }
+        }
     
     private var content: some View {
         Group {

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Cache/CachedImageLoader.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Cache/CachedImageLoader.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-@MainActor
 class CachedImageLoader: ObservableObject {
     @Published var image: UIImage?
     private var url: URL?

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Cache/ImageCacheManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Cache/ImageCacheManager.swift
@@ -25,8 +25,9 @@ actor ImageCacheManager {
         cacheDirectory = URL(fileURLWithPath: imageCachePath)
         
         createCacheDirectoryIfNeeded()
-        Task {
-            await cleanExpiredCache()
+        
+        Task.detached(priority: .background) {
+            await self.cleanExpiredCache()
         }
     }
     
@@ -44,30 +45,32 @@ actor ImageCacheManager {
         return memoryCache.object(forKey: url as NSString)
     }
     
-    func getImageFromDisk(for url: String) -> UIImage? {
-        let fileURL = cacheFileURL(for: url)
-        
-        guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
-        
-        do {
-            let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
-            if let modificationDate = attributes[.modificationDate] as? Date {
-                if Date().timeIntervalSince(modificationDate) > cacheExpirationTime {
-                    try? fileManager.removeItem(at: fileURL)
-                    return nil
+    func getImageFromDisk(for url: String) async -> UIImage? {
+        return await Task.detached(priority: .background) {
+            let fileURL = await self.cacheFileURL(for: url)
+            
+            guard self.fileManager.fileExists(atPath: fileURL.path) else { return nil }
+            
+            do {
+                let attributes = try self.fileManager.attributesOfItem(atPath: fileURL.path)
+                if let modificationDate = attributes[.modificationDate] as? Date {
+                    if Date().timeIntervalSince(modificationDate) > self.cacheExpirationTime {
+                        try? self.fileManager.removeItem(at: fileURL)
+                        return nil
+                    }
                 }
+                
+                let data = try Data(contentsOf: fileURL)
+                if let image = UIImage(data: data) {
+                    await self.saveImageToMemory(image, for: url)
+                    return image
+                }
+            } catch {
+                print("Error reading image from disk: \(error)")
             }
             
-            let data = try Data(contentsOf: fileURL)
-            if let image = UIImage(data: data) {
-                saveImageToMemory(image, for: url)
-                return image
-            }
-        } catch {
-            print("Error reading image from disk: \(error)")
-        }
-        
-        return nil
+            return nil
+        }.value
     }
     
     func saveImageToMemory(_ image: UIImage, for url: String) {
@@ -76,15 +79,17 @@ actor ImageCacheManager {
     }
     
     func saveImageToDisk(_ image: UIImage, for url: String) async {
-        guard let data = image.jpegData(compressionQuality: 0.8) else { return }
-        
-        let fileURL = cacheFileURL(for: url)
-        
-        do {
-            try data.write(to: fileURL)
-        } catch {
-            print("Error saving image to disk: \(error)")
-        }
+        await Task.detached(priority: .background) {
+            guard let data = image.jpegData(compressionQuality: 0.8) else { return }
+            
+            let fileURL = await self.cacheFileURL(for: url)
+            
+            do {
+                try data.write(to: fileURL)
+            } catch {
+                print("Error saving image to disk: \(error)")
+            }
+        }.value
     }
     
     private func cacheFileURL(for url: String) -> URL {
@@ -98,39 +103,43 @@ actor ImageCacheManager {
     }
     
     func cleanExpiredCache() async {
-        do {
-            let resourceKeys: [URLResourceKey] = [.contentModificationDateKey]
-            let fileURLs = try fileManager.contentsOfDirectory(at: cacheDirectory,
-                                                            includingPropertiesForKeys: resourceKeys)
-            
-            let now = Date()
-            
-            for fileURL in fileURLs {
-                guard let resourceValues = try? fileURL.resourceValues(forKeys: Set(resourceKeys)),
-                      let modificationDate = resourceValues.contentModificationDate else {
-                    continue
-                }
+        await Task.detached(priority: .background) {
+            do {
+                let resourceKeys: [URLResourceKey] = [.contentModificationDateKey]
+                let fileURLs = try await self.fileManager.contentsOfDirectory(at: self.cacheDirectory,
+                                                                includingPropertiesForKeys: resourceKeys)
                 
-                if now.timeIntervalSince(modificationDate) > cacheExpirationTime {
-                    try? fileManager.removeItem(at: fileURL)
+                let now = Date()
+                
+                for fileURL in fileURLs {
+                    guard let resourceValues = try? fileURL.resourceValues(forKeys: Set(resourceKeys)),
+                          let modificationDate = resourceValues.contentModificationDate else {
+                        continue
+                    }
+                    
+                    if now.timeIntervalSince(modificationDate) > self.cacheExpirationTime {
+                        try? await self.fileManager.removeItem(at: fileURL)
+                    }
                 }
+            } catch {
+                print("Error cleaning expired cache: \(error)")
             }
-        } catch {
-            print("Error cleaning expired cache: \(error)")
-        }
+        }.value
     }
     
     func clearAllCache() async {
         memoryCache.removeAllObjects()
         
-        do {
-            let contents = try fileManager.contentsOfDirectory(at: cacheDirectory,
-                                                           includingPropertiesForKeys: nil)
-            for fileURL in contents {
-                try fileManager.removeItem(at: fileURL)
+        await Task.detached(priority: .background) {
+            do {
+                let contents = try await self.fileManager.contentsOfDirectory(at: self.cacheDirectory,
+                                                               includingPropertiesForKeys: nil)
+                for fileURL in contents {
+                    try await self.fileManager.removeItem(at: fileURL)
+                }
+            } catch {
+                print("Error clearing disk cache: \(error)")
             }
-        } catch {
-            print("Error clearing disk cache: \(error)")
-        }
+        }.value
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Cache/ImageCacheManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Cache/ImageCacheManager.swift
@@ -14,7 +14,7 @@ actor ImageCacheManager {
     private let fileManager = FileManager.default
     private let cacheDirectory: URL
     
-    private let cacheExpirationTime: TimeInterval = 7 * 24 * 60 * 60 // 1주일
+    private let cacheExpirationTime: TimeInterval = 7 * 24 * 60 * 60 
     private var cleanupTask: Task<Void, Never>?
     
     private init() {
@@ -51,31 +51,32 @@ actor ImageCacheManager {
     }
     
     func getImageFromDisk(for url: String) async -> UIImage? {
-        let fileURL = cacheFileURL(for: url)
-        
-        guard fileManager.fileExists(atPath: fileURL.path) else {
-            return nil
-        }
+        return await Task.detached(priority: .background) {
+            let fileURL = await self.cacheFileURL(for: url)
+            let fileManager = FileManager()
+            
+            guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
 
-        do {
-            let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
-            if let modificationDate = attributes[.modificationDate] as? Date {
-                if Date().timeIntervalSince(modificationDate) > self.cacheExpirationTime {
-                    try? fileManager.removeItem(at: fileURL)
-                    return nil
+            do {
+                let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
+                if let modificationDate = attributes[.modificationDate] as? Date {
+                    if Date().timeIntervalSince(modificationDate) > self.cacheExpirationTime {
+                        try? fileManager.removeItem(at: fileURL)
+                        return nil
+                    }
                 }
+                
+                let data = try Data(contentsOf: fileURL)
+                if let image = UIImage(data: data) {
+                    await self.saveImageToMemory(image, for: url)
+                    return image
+                }
+            } catch {
+                print("Error reading image from disk: \(error)")
             }
             
-            let data = try Data(contentsOf: fileURL)
-            if let image = UIImage(data: data) {
-                saveImageToMemory(image, for: url)
-                return image
-            }
-        } catch {
-            print("Error reading image from disk: \(error)")
-        }
-        
-        return nil
+            return nil
+        }.value
     }
     
     func saveImageToMemory(_ image: UIImage, for url: String) {
@@ -84,19 +85,20 @@ actor ImageCacheManager {
     }
     
     func saveImageToDisk(_ image: UIImage, for url: String) async {
-        guard let data = image.jpegData(compressionQuality: 0.8) else { return }
-        
-        let fileURL = cacheFileURL(for: url)
-        
-        do {
-            try data.write(to: fileURL)
-        } catch {
-            print("Error saving image to disk: \(error)")
-        }
+        await Task.detached(priority: .background) {
+            guard let data = image.jpegData(compressionQuality: 0.8) else { return }
+            
+            let fileURL = await self.cacheFileURL(for: url)
+            
+            do {
+                try data.write(to: fileURL)
+            } catch {
+                print("Error saving image to disk: \(error)")
+            }
+        }.value
     }
     
     private func cacheFileURL(for url: String) -> URL {
-        // URL에 허용되지 않는 문자 대체
         let filename = url.replacingOccurrences(of: "/", with: "_")
                          .replacingOccurrences(of: ":", with: "_")
                          .replacingOccurrences(of: "?", with: "_")
@@ -107,45 +109,46 @@ actor ImageCacheManager {
     }
     
     func cleanExpiredCache() async {
-        do {
-            try Task.checkCancellation()
-            
-            let resourceKeys: [URLResourceKey] = [.contentModificationDateKey]
-            let fileURLs = try fileManager.contentsOfDirectory(at: cacheDirectory,
-                                                            includingPropertiesForKeys: resourceKeys)
-            
-            let now = Date()
-            
-            for fileURL in fileURLs {
-                try Task.checkCancellation()
+        await Task.detached(priority: .background) {
+            do {
+                let fileManager = FileManager()
+                let resourceKeys: [URLResourceKey] = [.contentModificationDateKey]
+                let fileURLs = try fileManager.contentsOfDirectory(at: self.cacheDirectory,
+                                                                includingPropertiesForKeys: resourceKeys)
                 
-                guard let resourceValues = try? fileURL.resourceValues(forKeys: Set(resourceKeys)),
-                      let modificationDate = resourceValues.contentModificationDate else {
-                    continue
-                }
+                let now = Date()
                 
-                if now.timeIntervalSince(modificationDate) > self.cacheExpirationTime {
-                    try? fileManager.removeItem(at: fileURL)
+                for fileURL in fileURLs {
+                    guard let resourceValues = try? fileURL.resourceValues(forKeys: Set(resourceKeys)),
+                          let modificationDate = resourceValues.contentModificationDate else {
+                        continue
+                    }
+                    
+                    if now.timeIntervalSince(modificationDate) > self.cacheExpirationTime {
+                        try? fileManager.removeItem(at: fileURL)
+                    }
                 }
+            } catch {
+                print("Error cleaning expired cache: \(error)")
             }
-        } catch is CancellationError {
-            return
-        } catch {
-            print("Error cleaning expired cache: \(error)")
-        }
+        }.value
     }
     
     func clearAllCache() async {
         memoryCache.removeAllObjects()
         
-        do {
-            let contents = try fileManager.contentsOfDirectory(at: cacheDirectory,
-                                                           includingPropertiesForKeys: nil)
-            for fileURL in contents {
-                try? fileManager.removeItem(at: fileURL)
+        await Task.detached(priority: .background) {
+            do {
+                let fileManager = FileManager()
+
+                let contents = try fileManager.contentsOfDirectory(at: self.cacheDirectory,
+                                                               includingPropertiesForKeys: nil)
+                for fileURL in contents {
+                    try fileManager.removeItem(at: fileURL)
+                }
+            } catch {
+                print("Error clearing disk cache: \(error)")
             }
-        } catch {
-            print("Error clearing disk cache: \(error)")
-        }
+        }.value
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #193 

## 📄 작업 내용
- 메모리 누수 해결
- 데이터 레이스 해결
- 구조화된 동시성 사용

### 기능내용이기에 GIF는 생략합니다 (이전PR과 동일)

메모리 누수 관련해서 이전 코드에서 `diskIOQueue`에서 싱글톤으로 참조중이였기에 작업이완료되지 않는 상황에서 참조 사이클이 발생할 잠재적 위험을 확인했습니다.

또한, 메인스레드에서의 업데이트, Concurrency등 더 발전시킬 코드들이 있어 작업을 했습니다

actor의 개념이 나와서 혼란스러우실수도 있겟지만

해당 PR 에서는 Concurrency에 대해 직접적으로 설명하지는 않겟습니다.

코멘트로 잘 모르는 부분이나 이해가 되지 않는 부분들 남겨주시면 코멘트 부분에서 설명해드릴게요!

좀더 깊은 이해를 위해서는 actor에 대해서 먼저 학습을 하고 오셔도 좋을것같습니다.

## 구조화된 동시성 사용


### 구조화된 동시성에서 취소 전파 지점

### 1. CachedImageLoader에서의 취소 전파

```swift
func load() async {
    loadTask?.cancel()

    loadTask = Task {
        do {
            // 작업 내부에서 취소 확인
            if !Task.isCancelled {
                self.image = cachedImage
            }

            // 네트워크 요청에서 취소 핸들러 사용
            let imageData = try await withTaskCancellationHandler {
                try await URLSession.shared.data(from: url).0
            } onCancel: {
                // 취소 처리 - URLSession 태스크는 자동으로 취소
            }

            // 취소 확인 후 작업 계속
            guard !Task.isCancelled else { return }

            // 결과 처리에서도 취소 확인
            if !Task.isCancelled {
                self.image = downloadedImage
            }
        } catch {
            // 오류 처리에서도 취소 확인
            if !Task.isCancelled {
                // ...
            }
        }
    }
}

```

1. `loadTask?.cancel()`을 호출하면 이전 작업이 취소됨
2. 새 작업 내부에서 여러 지점에서 `Task.isCancelled`를 검사하여 취소된 경우 추가 작업수행 X
3. `withTaskCancellationHandler`를 사용하여 네트워크 요청의 취소를 처리
    - 작업이 취소되면 자동으로 `onCancel` 핸들러가 호출됨
    - URLSession 작업은 Task가 취소될 때 자동으로 같이 취소됩니다.

### 2. ImageCacheManager에서의 취소 전파

```swift
func cleanExpiredCache() async {
    do {
        try Task.checkCancellation()

        // ... 파일 목록 가져오기 ...

        for fileURL in fileURLs {
            try Task.checkCancellation()

            // ... 파일 처리 ...
        }
    } catch is CancellationError {
        return
    } catch {
        // ... 오류 처리 ...
    }
}
```

1. `Task.checkCancellation()`을 호출하여 작업이 취소되었는지 확인
    - 취소된 경우 `CancellationError`를 던져 작업을 즉시 중단.
2. 루프 내부에서도 정기적으로 `Task.checkCancellation()`을 호출하여 긴 작업 도중에도 취소확인
3. `catch is CancellationError` 블록에서 취소 오류를 처리

### 3. 생명주기 관리를 통한 취소 전파

```swift
// CachedImageLoader에서
deinit {
    cancelLoad()
}

// ImageCacheManager에서
deinit {
    cleanupTask?.cancel()
}

```

뷰가 사라질 때 관련된 모든 비동기 작업도 자동으로 취소됩니당.

### 4. CachedImage 뷰에서의 취소 전파

```swift
var body: some View {
    content
        .task {
            await loader.load()
        }
}
```

`.task` 모디파이어는 뷰의 생명주기와 연결됩니다:

1. 뷰가 나타날 때 작업이 시작됩니다.
2. 뷰가 사라질 때(예: 화면에서 제거되거나 부모 뷰가 사라질 때) 작업이 자동으로 취소됩니다.
3. 이 취소는 `loader.load()`를 통해 `CachedImageLoader`의 작업으로 전파됩니다.

## 취소 전파의 흐름

1. 사용자가 화면을 떠나거나 뷰가 사라지면 → SwiftUI가 `.task` 작업을 취소
2. `.task` 취소는 → `loader.load()` 작업을 취소
3. `loader.load()` 취소는 → 내부 `loadTask`를 취소하고 진행 중인 네트워크 요청을 취소
4. 각 취소 지점에서 `Task.isCancelled` 또는 `Task.checkCancellation()`을 통해 작업 진행 여부 결정

## `actor` 키워드와 데이터 레이스 방지

- actor 내부의 모든 변경 가능한 상태에 대한 접근은 자동으로 직렬화 시켯습니다.
- 이전에 명진님이 말해주엇던 메모리 캐시와 디스크 캐시에 동시에 접근할 때 발생할 수 있는 충돌을 방지하고자 넣었습니다.

## 3. `Task.detached` 사용

백그라운드 작업을 위해 `Task.detached`를 사용했습니다

```swift
Task.detached(priority: .background) {
    // 백그라운드 작업
}
```

## 4. 작업 취소 메커니즘

`CachedImageLoader`에서는 작업 취소 메커니즘을 구현했습니다

```swift
func cancel() {
    task?.cancel()
    task = nil
    isLoading = false
}

```

그리고 작업 중간중간에 취소 확인을 합니다:

```swift
guard !Task.isCancelled else {
    self.isLoading = false
    return
}

```

- 이미지가 더 이상 필요하지 않을 때 (예: 뷰가 사라질 때) 리소스를 절약하기 위해 작업을 취소합니다.
- `Task.isCancelled`를 사용하여 작업이 취소되었는지 정기적으로 확인합니다.

## Sendable 관련 경고
<img width="568" alt="스크린샷 2025-03-06 오후 3 35 29" src="https://github.com/user-attachments/assets/179bb1b9-de66-4401-bb9d-179150b84e3e" />


현재 코드에서 왜 FileManager()을 지역변수로 선언했는지에 대해 말해보자면

현재 Swift에서 `FileManager`는 `Sendable`을 준수하지 않도록 선언되어 있습니다. 이는 Swift 언어와 표준 라이브러리 개발자들이 `FileManager`가 모든 상황에서 완전히 스레드 안전하지 않다고 생각해서 일거같아요

(stricted Swift로 인해 비동기 처리가 참 귀찮아지는 경우 발생!)
<img width="566" alt="스크린샷 2025-03-06 오후 3 35 38" src="https://github.com/user-attachments/assets/140fb030-65ec-45c6-a8e5-0724e3c3a4c5" />


## 실제 스레드 안전성 vs 타입 시스템의 보장

차이점은 "실제 스레드 안전성"과 "타입 시스템이 보장하는 안전성" 사이의 차이입니다:

1. **실제 스레드 안전성**: Apple 문서에 따르면 `FileManager`의 메서드는 일반적으로 스레드 안전합니다(델리게이트 없이 사용할 때).
2. **타입 시스템의 보장**: Swift의 타입 시스템은 이런 미묘한 구분을 할 수 없어서, `FileManager`를 `Sendable`  하지 않은것으로 생각하는듯 합니다

## 왜 여전히 새 인스턴스를 만들어야 하는가?

Swift의 액터 모델은 격리를 제공하지만, 그 격리는 컴파일러가 검증할 수 있어야 합니다. `FileManager`가 `Sendable`을 준수하지 않는다면, 컴파일러는 안전성을 보장할 수 없으므로 액터 경계를 넘는 것을 허용하지 않습니다

따라서 "실제로" `FileManager`가 대부분의 상황에서 스레드 안전할 수 있지만, Swift의 타입 시스템은 이런 미묘한 구분을 할 수 없어서 더 매섭게 지역변수로 세팅을 해두었습니다.


## 📚 참고자료
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md

## 👀 기타 더 이야기해볼 점
ImageCacheManager부분의  24 25 번째 줄에서 노란색 오류가 나고있습니다! 왜냐면 `ImageCacheManager` 클래스에 있는 `createCacheDirectoryIfNeeded()`랑 `scheduleCleanup() `메서드가 액터로 격리되어 있는데, 격리되지 않은 컨텍스트에서 이 메서드를 호출하고 있어서 컴파일에서 잡고 있는겁니다.

init() 메서드는 Swift 액터에서 특수케이스(?)로 뽑고있어서 init()은 기본적으로 격리되지 않은 상태로 실행이 됩니다. 왜냐면 액터의 초기화 과정에서는 아직 액터의 격리 시스템이 완전히 설정이 안되었기에 격리된 메서드인 `createCacheDirectoryIfNeeded()`랑 `scheduleCleanup()` 메서드를 격리되지 않은 컨텍스트인 init()에서 직접 호출할수 없어서 그렇습니다.

간단하게 생각해서 nonisolation 키워드나 Task 컨텍스트로 따로 빼서 사용하려 했으나 메서드가 액터의 내부 상태를 접근하지 않을 때 작동해야하는데 격리된 속성에 접근하기 때문에 또다른 에러가 반복되어서 결국 불필요한 코드가 너무 많아질거라 생각이 되었습니다.
해당 오류를 잡으려면 격리 비격리를 온전히 다 나누고 초기화 로직을 비우는게 좋을것 같은데 해당 방법으로 어떤식으로 진행해야될지 정확하게 모르겟습니다 추후 공부하면서 다시 수정해보도록 할게요!
