### PR TITLE
fix: icon 버튼 연속 액션 호출 수정

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextField.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextField.swift
@@ -16,6 +16,7 @@ public struct SpoonyTextField: View {
     
     // MARK: - Properties
     @State private var errorState: TextFieldErrorState = .initial
+    @State private var disabled: Bool = false
     @FocusState private var isFocused
     @Binding var text: String
     @Binding var isError: Bool
@@ -119,6 +120,11 @@ extension SpoonyTextField {
                     Button {
                         if let action = action {
                             action()
+                            disabled = true
+                            Task { @MainActor in
+                                try? await Task.sleep(for: .seconds(0.5))
+                                disabled = false
+                            }
                         }
                     } label: {
                         if let icon = style.trailingIcon,
@@ -128,6 +134,7 @@ extension SpoonyTextField {
                                 .frame(width: size, height: size)
                         }
                     }
+                    .disabled(disabled)
                 case .icon:
                     if !text.isEmpty {
                         Button {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #205 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- ForEach를 통해 recommendTexts를 반복해서 SpoonyTextField를 생성후 바인딩 해줬는데 
이 과정에서 삭제 아이콘을 연속 클릭시 삭제후 recommendTexts가 ForEach 부분에 반영되기 전에
이미 삭제된 recommendText에 접근하게 되어 인덱스 오류가 발생했습니다.
SpoonyTextField에 disabled 값을 설정하여 일정 시간 뒤에 클릭이 가능해지도록 하여 수정했습니다.

