### PR TITLE
[Style/#249] MyPage 뷰연결

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/TestScenes/MyPageCoordinator/MyPageCoordinator.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/TestScenes/MyPageCoordinator/MyPageCoordinator.swift
@@ -49,13 +49,43 @@ struct MyPageCoordinator {
                 state.routes.push(.attendance(.initialState))
                 return .none
                 
+            case .router(.routeAction(id: _, action: .settings(.routeToAccountManagementScreen))):
+                state.routes.push(.accountManagement(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToBlockedUsersScreen))):
+                state.routes.push(.blockedUsers(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToTermsOfServiceScreen))):
+                state.routes.push(.termsOfService(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToPrivacyPolicyScreen))):
+                state.routes.push(.privacyPolicy(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToLocationServicesScreen))):
+                state.routes.push(.locationServices(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToInquiryScreen))):
+                state.routes.push(.inquiry(.initialState))
+                return .none
+                
             // 이전 화면으로 돌아가기
             case .router(.routeAction(id: _, action: .reviews(.routeToPreviousScreen))),
-                 .router(.routeAction(id: _, action: .following(.routeToPreviousScreen))),
-                 .router(.routeAction(id: _, action: .follower(.routeToPreviousScreen))),
-                 .router(.routeAction(id: _, action: .editProfile(.routeToPreviousScreen))),
-                 .router(.routeAction(id: _, action: .settings(.routeToPreviousScreen))),
-                 .router(.routeAction(id: _, action: .attendance(.routeToPreviousScreen))):
+                    .router(.routeAction(id: _, action: .following(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .follower(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .editProfile(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .settings(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .attendance(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .accountManagement(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .blockedUsers(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .termsOfService(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .privacyPolicy(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .locationServices(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .inquiry(.routeToPreviousScreen))):
                 state.routes.goBack()
                 return .none
                 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/MyPageView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/MyPageView.swift
@@ -19,6 +19,13 @@ enum MyPageScreen {
     case editProfile(EditProfileFeature)
     case settings(SettingsFeature)
     case attendance(AttendanceFeature)
+    
+    case accountManagement(AccountManagementFeature)
+    case blockedUsers(BlockedUsersFeature)
+    case termsOfService(TermsOfServiceFeature)
+    case privacyPolicy(PrivacyPolicyFeature)
+    case locationServices(LocationServicesFeature)
+    case inquiry(InquiryFeature)
 }
 
 struct MyPageView: View {
@@ -47,6 +54,26 @@ struct MyPageView: View {
                 MealTrackerView(store: store)
                     .navigationBarBackButtonHidden()
                     .toolbar(.hidden, for: .tabBar)
+                
+            // 설정 관련 화면들 추가
+            case let .accountManagement(store):
+                AccountManagementView(store: store)
+                    .navigationBarBackButtonHidden()
+            case let .blockedUsers(store):
+                BlockedUsersView(store: store)
+                    .navigationBarBackButtonHidden()
+            case let .termsOfService(store):
+                TermsOfServiceView(store: store)
+                    .navigationBarBackButtonHidden()
+            case let .privacyPolicy(store):
+                PrivacyPolicyView(store: store)
+                    .navigationBarBackButtonHidden()
+            case let .locationServices(store):
+                LocationServicesView(store: store)
+                    .navigationBarBackButtonHidden()
+            case let .inquiry(store):
+                InquiryView(store: store)
+                    .navigationBarBackButtonHidden()
             }
         }
     }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
@@ -1,0 +1,30 @@
+//
+//  AccountManagementFeature.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct AccountManagementFeature {
+    @ObservableState
+    struct State: Equatable {
+        static let initialState = State()
+    }
+    
+    enum Action {
+        case routeToPreviousScreen
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .routeToPreviousScreen:
+                return .none
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
@@ -1,0 +1,39 @@
+//
+//  AccountManagementView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct AccountManagementView: View {
+    @Bindable private var store: StoreOf<AccountManagementFeature>
+    
+    init(store: StoreOf<AccountManagementFeature>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            CustomNavigationBar(
+                style: .detail,
+                title: "계정 관리",
+                searchText: .constant(""),
+                onBackTapped: {
+                    store.send(.routeToPreviousScreen)
+                }
+            )
+            
+            Spacer()
+            
+            Text("계정 관리 화면")
+                .font(.title2)
+            
+            Spacer()
+        }
+        .background(Color.white)
+        .navigationBarHidden(true)
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/BlockedUsersFeature/BlockedUsersFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/BlockedUsersFeature/BlockedUsersFeature.swift
@@ -1,0 +1,30 @@
+//
+//  BlockedUsersFeature.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct BlockedUsersFeature {
+    @ObservableState
+    struct State: Equatable {
+        static let initialState = State()
+    }
+    
+    enum Action {
+        case routeToPreviousScreen
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .routeToPreviousScreen:
+                return .none
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/BlockedUsersFeature/BlockedUsersView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/BlockedUsersFeature/BlockedUsersView.swift
@@ -1,0 +1,39 @@
+//
+//  BlockedUsersView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct BlockedUsersView: View {
+    @Bindable private var store: StoreOf<BlockedUsersFeature>
+    
+    init(store: StoreOf<BlockedUsersFeature>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            CustomNavigationBar(
+                style: .detail,
+                title: "차단한 유저",
+                searchText: .constant(""),
+                onBackTapped: {
+                    store.send(.routeToPreviousScreen)
+                }
+            )
+            
+            Spacer()
+            
+            Text("차단한 유저 화면")
+                .font(.title2)
+            
+            Spacer()
+        }
+        .background(Color.white)
+        .navigationBarHidden(true)
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/InquiryFeature/InquiryFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/InquiryFeature/InquiryFeature.swift
@@ -1,0 +1,44 @@
+//
+//  InquiryFeature.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct InquiryFeature {
+    @ObservableState
+    struct State: Equatable {
+        static let initialState = State()
+        
+        var inquiryText: String = ""
+        var isSubmitEnabled: Bool = false
+    }
+    
+    enum Action {
+        case routeToPreviousScreen
+        case updateInquiryText(String)
+        case submitButtonTapped
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .routeToPreviousScreen:
+                return .none
+                
+            case let .updateInquiryText(text):
+                state.inquiryText = text
+                state.isSubmitEnabled = !text.isEmpty
+                return .none
+                
+            case .submitButtonTapped:
+                // 여기에 문의 제출 로직 추가
+                return .none
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/InquiryFeature/InquiryView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/InquiryFeature/InquiryView.swift
@@ -1,0 +1,36 @@
+//
+//  InquiryView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct InquiryView: View {
+    @Bindable private var store: StoreOf<InquiryFeature>
+    
+    init(store: StoreOf<InquiryFeature>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            CustomNavigationBar(
+                style: .detail,
+                title: "1:1 문의",
+                searchText: .constant(""),
+                onBackTapped: {
+                    store.send(.routeToPreviousScreen)
+                }
+            )
+        }
+    }
+}
+
+#Preview {
+    InquiryView(store: Store(initialState: .initialState, reducer: {
+        InquiryFeature()
+    }))
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/LocationFeature/LocationServicesFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/LocationFeature/LocationServicesFeature.swift
@@ -1,0 +1,30 @@
+//
+//  LocationServicesFeature.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct LocationServicesFeature {
+    @ObservableState
+    struct State: Equatable {
+        static let initialState = State()
+    }
+    
+    enum Action {
+        case routeToPreviousScreen
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .routeToPreviousScreen:
+                return .none
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/LocationFeature/LocationServicesView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/LocationFeature/LocationServicesView.swift
@@ -1,0 +1,56 @@
+//
+//  LocationServicesView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct LocationServicesView: View {
+    @Bindable private var store: StoreOf<LocationServicesFeature>
+    
+    init(store: StoreOf<LocationServicesFeature>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            CustomNavigationBar(
+                style: .detail,
+                title: "위치기반서비스 이용약관",
+                searchText: .constant(""),
+                onBackTapped: {
+                    store.send(.routeToPreviousScreen)
+                }
+            )
+            
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("위치기반서비스 이용약관")
+                        .font(.title3b)
+                        .padding(.top, 20)
+                    
+                    Text("이 약관은 스푸니의 위치기반서비스 이용에 관한 내용을 담고 있습니다.")
+                        .font(.body2m)
+                        .foregroundStyle(.gray700)
+                        .padding(.bottom, 20)
+                    
+                    Text("위치기반서비스 이용약관 내용이 여기에 표시됩니다.")
+                        .font(.body2m)
+                        .foregroundStyle(.gray700)
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+        .background(Color.white)
+        .navigationBarHidden(true)
+    }
+}
+
+#Preview {
+    LocationServicesView(store: Store(initialState: .initialState, reducer: {
+        LocationServicesFeature()
+    }))
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/PrivacyPolicy/PrivacyPolicyFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/PrivacyPolicy/PrivacyPolicyFeature.swift
@@ -1,0 +1,30 @@
+//
+//  PrivacyPolicyFeature.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct PrivacyPolicyFeature {
+    @ObservableState
+    struct State: Equatable {
+        static let initialState = State()
+    }
+    
+    enum Action {
+        case routeToPreviousScreen
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .routeToPreviousScreen:
+                return .none
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/PrivacyPolicy/PrivacyPolicyView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/PrivacyPolicy/PrivacyPolicyView.swift
@@ -1,0 +1,56 @@
+//
+//  PrivacyPolicyView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct PrivacyPolicyView: View {
+    @Bindable private var store: StoreOf<PrivacyPolicyFeature>
+    
+    init(store: StoreOf<PrivacyPolicyFeature>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            CustomNavigationBar(
+                style: .detail,
+                title: "개인정보 처리 방침",
+                searchText: .constant(""),
+                onBackTapped: {
+                    store.send(.routeToPreviousScreen)
+                }
+            )
+            
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("개인정보 처리 방침")
+                        .font(.title3b)
+                        .padding(.top, 20)
+                    
+                    Text("이 방침은 스푸니의 개인정보 처리 방법에 대한 내용을 담고 있습니다.")
+                        .font(.body2m)
+                        .foregroundStyle(.gray700)
+                        .padding(.bottom, 20)
+                    
+                    Text("개인정보 처리 방침 내용이 여기에 표시됩니다.")
+                        .font(.body2m)
+                        .foregroundStyle(.gray700)
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+        .background(Color.white)
+        .navigationBarHidden(true)
+    }
+}
+
+#Preview {
+    PrivacyPolicyView(store: Store(initialState: .initialState, reducer: {
+        PrivacyPolicyFeature()
+    }))
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/SettingFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/SettingFeature.swift
@@ -26,7 +26,6 @@ struct SettingsFeature {
         static let initialState = State()
         
         var isLoading: Bool = false
-        var destination: SettingsScreenType?
     }
     
     enum Action {
@@ -38,9 +37,7 @@ struct SettingsFeature {
         case didTapPrivacyPolicy
         case didTapLocationServices
         case didTapInquiry
-        case setDestination(SettingsScreenType?)
         
-        // 실제 라우팅 액션 추가
         case routeToAccountManagementScreen
         case routeToBlockedUsersScreen
         case routeToTermsOfServiceScreen
@@ -75,10 +72,6 @@ struct SettingsFeature {
                 
             case .didTapInquiry:
                 return .send(.routeToInquiryScreen)
-                
-            case let .setDestination(destination):
-                state.destination = destination
-                return .none
                 
             case .routeToAccountManagementScreen,
                  .routeToBlockedUsersScreen,

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/SettingFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/SettingFeature.swift
@@ -9,21 +9,83 @@ import SwiftUI
 
 import ComposableArchitecture
 import TCACoordinators
+
+enum SettingsScreenType {
+    case accountManagement
+    case blockedUsers
+    case termsOfService
+    case privacyPolicy
+    case locationServices
+    case inquiry
+}
+
 @Reducer
 struct SettingsFeature {
     @ObservableState
     struct State: Equatable {
         static let initialState = State()
+        
+        var isLoading: Bool = false
+        var destination: SettingsScreenType?
     }
     
     enum Action {
         case routeToPreviousScreen
+        case onAppear
+        case didTapAccountManagement
+        case didTapBlockedUsers
+        case didTapServiceTerms
+        case didTapPrivacyPolicy
+        case didTapLocationServices
+        case didTapInquiry
+        case setDestination(SettingsScreenType?)
+        
+        // 실제 라우팅 액션 추가
+        case routeToAccountManagementScreen
+        case routeToBlockedUsersScreen
+        case routeToTermsOfServiceScreen
+        case routeToPrivacyPolicyScreen
+        case routeToLocationServicesScreen
+        case routeToInquiryScreen
     }
     
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .routeToPreviousScreen:
+                return .none
+                
+            case .onAppear:
+                return .none
+                
+            case .didTapAccountManagement:
+                return .send(.routeToAccountManagementScreen)
+                
+            case .didTapBlockedUsers:
+                return .send(.routeToBlockedUsersScreen)
+                
+            case .didTapServiceTerms:
+                return .send(.routeToTermsOfServiceScreen)
+                
+            case .didTapPrivacyPolicy:
+                return .send(.routeToPrivacyPolicyScreen)
+                
+            case .didTapLocationServices:
+                return .send(.routeToLocationServicesScreen)
+                
+            case .didTapInquiry:
+                return .send(.routeToInquiryScreen)
+                
+            case let .setDestination(destination):
+                state.destination = destination
+                return .none
+                
+            case .routeToAccountManagementScreen,
+                 .routeToBlockedUsersScreen,
+                 .routeToTermsOfServiceScreen,
+                 .routeToPrivacyPolicyScreen,
+                 .routeToLocationServicesScreen,
+                 .routeToInquiryScreen:
                 return .none
             }
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/SettingsView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/SettingsView.swift
@@ -18,22 +18,97 @@ struct SettingsView: View {
     }
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             CustomNavigationBar(
                 style: .detail,
+                title: "설정",
                 searchText: .constant(""),
                 onBackTapped: {
                     store.send(.routeToPreviousScreen)
                 }
             )
             
-            Spacer()
-            
-            Text("Settings View")
-                .font(.largeTitle)
+            VStack(spacing: 0) {
+                sectionHeader(title: "계정")
+                
+                settingsRow(title: "계정 관리", hasArrow: true) {
+                    store.send(.didTapAccountManagement)
+                }
+                
+                sectionHeader(title: "기타")
+                
+                settingsRow(title: "차단한 유저", hasArrow: true) {
+                    store.send(.didTapBlockedUsers)
+                }
+                Divider()
+                    .padding(.leading, 20)
+                
+                settingsRow(title: "서비스 이용약관", hasArrow: true) {
+                    store.send(.didTapServiceTerms)
+                }
+                
+                settingsRow(title: "개인정보 처리 방침", hasArrow: true) {
+                    store.send(.didTapPrivacyPolicy)
+                }
+                
+                settingsRow(title: "위치기반서비스 이용약관", hasArrow: true) {
+                    store.send(.didTapLocationServices)
+                }
+                
+                settingsRow(title: "1:1 문의", hasArrow: true) {
+                    store.send(.didTapInquiry)
+                }
+                Spacer()
+            }
+        }
+        .background(Color.white)
+        .navigationBarHidden(true)
+        .task {
+            store.send(.onAppear)
+        }
+    }
+    
+    private func sectionHeader(title: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.caption1m)
+                .foregroundStyle(.gray600)
+                .padding(.leading, 20)
+                .padding(.vertical, 8)
             
             Spacer()
         }
-        .navigationBarHidden(true)
+        .frame(maxWidth: .infinity)
+        .background(Color.gray0)
+    }
+    
+    private func settingsRow(title: String, hasArrow: Bool = false, action: (() -> Void)? = nil) -> some View {
+        Button(action: {
+            action?()
+        }) {
+            HStack {
+                Text(title)
+                    .font(.body2m)
+                    .foregroundStyle(.gray700)
+                    .padding(.vertical, 16)
+                
+                Spacer()
+                
+                if hasArrow {
+                    Image(.icArrowRightGray400)
+                }
+            }
+            .padding(.horizontal, 20)
+            .background(Color.white)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    NavigationView {
+        SettingsView(store: Store(initialState: .initialState, reducer: {
+            SettingsFeature()
+        }))
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/TermsOfServiceFeature/TermsOfServiceFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/TermsOfServiceFeature/TermsOfServiceFeature.swift
@@ -1,0 +1,31 @@
+//
+//  TermsOfServiceFeature.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct TermsOfServiceFeature {
+    @ObservableState
+    struct State: Equatable {
+        static let initialState = State()
+    }
+    
+    enum Action {
+        case routeToPreviousScreen
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .routeToPreviousScreen:
+                return .none
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/TermsOfServiceFeature/TermsOfServiceView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/TermsOfServiceFeature/TermsOfServiceView.swift
@@ -1,0 +1,50 @@
+//
+//  TermsOfServiceView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 4/25/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct TermsOfServiceView: View {
+    @Bindable private var store: StoreOf<TermsOfServiceFeature>
+    
+    init(store: StoreOf<TermsOfServiceFeature>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack {
+            CustomNavigationBar(
+                style: .detail,
+                title: "서비스 이용약관",
+                searchText: .constant(""),
+                onBackTapped: {
+                    store.send(.routeToPreviousScreen)
+                }
+            )
+            
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("서비스 이용약관")
+                        .font(.title3b)
+                        .padding(.top, 20)
+                    
+                    Text("이 약관은 스푸니 서비스 이용에 관한 내용을 담고 있습니다.")
+                        .font(.body2m)
+                        .foregroundStyle(.gray700)
+                        .padding(.bottom, 20)
+                    
+                    Text("약관 내용이 여기에 표시됩니다.")
+                        .font(.body2m)
+                        .foregroundStyle(.gray700)
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+        .background(Color.white)
+        .navigationBarHidden(true)
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #249 

## 📄 작업 내용
- 마이페이지에 딸려오는 설정 뷰 코디네이터와 뷰들을 연결햇습니다
- 뷰 내 뷰 는 다음 PR에~ ( 코드가 너무 길어짐

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/fd2fe197-9bd9-4e6f-ae9f-b15e516e8319" width ="250"> | <img src = "" width ="250"> |

## 👀 기타 더 이야기해볼 점
각 뷰 내에 있는 내용들 (계정관리, 서비스 이용약관 내부 등,,)은 전부 GPT로 깡통만 만든거니 신경쓰지 마세요~