### PR TITLE
[Style/#268] 회원탈퇴뷰 구현

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/TestScenes/MyPageCoordinator/MyPageCoordinator.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/TestScenes/MyPageCoordinator/MyPageCoordinator.swift
@@ -48,6 +48,38 @@ struct MyPageCoordinator {
             case .router(.routeAction(id: _, action: .profile(.routeToAttendanceScreen))):
                 state.routes.push(.attendance(.initialState))
                 return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToAccountManagementScreen))):
+                state.routes.push(.accountManagement(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToBlockedUsersScreen))):
+                state.routes.push(.blockedUsers(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToTermsOfServiceScreen))):
+                state.routes.push(.termsOfService(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToPrivacyPolicyScreen))):
+                state.routes.push(.privacyPolicy(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToLocationServicesScreen))):
+                state.routes.push(.locationServices(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .settings(.routeToInquiryScreen))):
+                state.routes.push(.inquiry(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .accountManagement(.routeToLogoutScreen))):
+                state.routes.push(.logout(.initialState))
+                return .none
+                
+            case .router(.routeAction(id: _, action: .accountManagement(.routeToWithdrawScreen))):
+                state.routes.push(.withdraw(.initialState))
+                return .none
               
             // 이전 화면으로 돌아가기
             case .router(.routeAction(id: _, action: .reviews(.routeToPreviousScreen))),
@@ -61,7 +93,9 @@ struct MyPageCoordinator {
                     .router(.routeAction(id: _, action: .termsOfService(.routeToPreviousScreen))),
                     .router(.routeAction(id: _, action: .privacyPolicy(.routeToPreviousScreen))),
                     .router(.routeAction(id: _, action: .locationServices(.routeToPreviousScreen))),
-                    .router(.routeAction(id: _, action: .inquiry(.routeToPreviousScreen))):
+                    .router(.routeAction(id: _, action: .inquiry(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .logout(.routeToPreviousScreen))),
+                    .router(.routeAction(id: _, action: .withdraw(.routeToPreviousScreen))):
                 state.routes.goBack()
                 return .none
                 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/TestScenes/MyPageCoordinator/MyPageCoordinator.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/TestScenes/MyPageCoordinator/MyPageCoordinator.swift
@@ -73,15 +73,10 @@ struct MyPageCoordinator {
                 state.routes.push(.inquiry(.initialState))
                 return .none
                 
-            case .router(.routeAction(id: _, action: .accountManagement(.routeToLogoutScreen))):
-                state.routes.push(.logout(.initialState))
-                return .none
-                
             case .router(.routeAction(id: _, action: .accountManagement(.routeToWithdrawScreen))):
                 state.routes.push(.withdraw(.initialState))
                 return .none
               
-            // 이전 화면으로 돌아가기
             case .router(.routeAction(id: _, action: .reviews(.routeToPreviousScreen))),
                     .router(.routeAction(id: _, action: .following(.routeToPreviousScreen))),
                     .router(.routeAction(id: _, action: .follower(.routeToPreviousScreen))),
@@ -94,7 +89,6 @@ struct MyPageCoordinator {
                     .router(.routeAction(id: _, action: .privacyPolicy(.routeToPreviousScreen))),
                     .router(.routeAction(id: _, action: .locationServices(.routeToPreviousScreen))),
                     .router(.routeAction(id: _, action: .inquiry(.routeToPreviousScreen))),
-                    .router(.routeAction(id: _, action: .logout(.routeToPreviousScreen))),
                     .router(.routeAction(id: _, action: .withdraw(.routeToPreviousScreen))):
                 state.routes.goBack()
                 return .none

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/MyPageView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/MyPageView.swift
@@ -26,6 +26,9 @@ enum MyPageScreen {
     case privacyPolicy(PrivacyPolicyFeature)
     case locationServices(LocationServicesFeature)
     case inquiry(InquiryFeature)
+    
+    case logout(LogoutFeature)
+    case withdraw(WithdrawFeature)
 }
 
 struct MyPageView: View {
@@ -55,7 +58,7 @@ struct MyPageView: View {
                     .navigationBarBackButtonHidden()
                     .toolbar(.hidden, for: .tabBar)
                 
-            // 설정 관련 화면들 추가
+                // 설정 관련 화면들 추가
             case let .accountManagement(store):
                 AccountManagementView(store: store)
                     .navigationBarBackButtonHidden()
@@ -73,6 +76,13 @@ struct MyPageView: View {
                     .navigationBarBackButtonHidden()
             case let .inquiry(store):
                 InquiryView(store: store)
+                    .navigationBarBackButtonHidden()
+                
+            case let .logout(store):
+                LogoutView(store: store)
+                    .navigationBarBackButtonHidden()
+            case let .withdraw(store):
+                WithdrawView(store: store)
                     .navigationBarBackButtonHidden()
             }
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
@@ -20,20 +20,33 @@ struct AccountManagementFeature {
         static let initialState = State(currentLoginType: .kakao)
         
         var currentLoginType: LoginType
+        var logoutAlert: LogoutAlert?
     }
     
-    enum Action {
+    enum LogoutAlert: Equatable {
+        case confirmLogout
+    }
+    
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
         case routeToPreviousScreen
         case selectLoginType(LoginType)
         case logoutButtonTapped
+        case confirmLogout
+        case cancelLogout
         case withdrawButtonTapped
-        case routeToLogoutScreen
         case routeToWithdrawScreen
+        case performLogout
     }
     
     var body: some ReducerOf<Self> {
+        BindingReducer()
+        
         Reduce { state, action in
             switch action {
+            case .binding:
+                return .none
+                
             case .routeToPreviousScreen:
                 return .none
                 
@@ -42,12 +55,24 @@ struct AccountManagementFeature {
                 return .none
                 
             case .logoutButtonTapped:
-                return .send(.routeToLogoutScreen)
+                state.logoutAlert = .confirmLogout
+                return .none
+                
+            case .confirmLogout:
+                state.logoutAlert = nil
+                return .send(.performLogout)
+                
+            case .cancelLogout:
+                state.logoutAlert = nil
+                return .none
                 
             case .withdrawButtonTapped:
                 return .send(.routeToWithdrawScreen)
                 
-            case .routeToLogoutScreen, .routeToWithdrawScreen:
+            case .routeToWithdrawScreen:
+                return .none
+                
+            case .performLogout:
                 return .none
             }
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
@@ -10,19 +10,44 @@ import ComposableArchitecture
 
 @Reducer
 struct AccountManagementFeature {
+    enum LoginType: Equatable {
+        case apple
+        case kakao
+    }
+    
     @ObservableState
     struct State: Equatable {
-        static let initialState = State()
+        static let initialState = State(currentLoginType: .kakao)
+        
+        var currentLoginType: LoginType
     }
     
     enum Action {
         case routeToPreviousScreen
+        case selectLoginType(LoginType)
+        case logoutButtonTapped
+        case withdrawButtonTapped
+        case routeToLogoutScreen
+        case routeToWithdrawScreen
     }
     
     var body: some ReducerOf<Self> {
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
             case .routeToPreviousScreen:
+                return .none
+                
+            case let .selectLoginType(type):
+                state.currentLoginType = type
+                return .none
+                
+            case .logoutButtonTapped:
+                return .send(.routeToLogoutScreen)
+                
+            case .withdrawButtonTapped:
+                return .send(.routeToWithdrawScreen)
+                
+            case .routeToLogoutScreen, .routeToWithdrawScreen:
                 return .none
             }
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
@@ -16,24 +16,108 @@ struct AccountManagementView: View {
     }
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
+            // 네비게이션 바
             CustomNavigationBar(
                 style: .detail,
                 title: "계정 관리",
-                searchText: .constant(""),
                 onBackTapped: {
                     store.send(.routeToPreviousScreen)
                 }
             )
             
-            Spacer()
+            // 로그인 타입 섹션
+            VStack(spacing: 0) {
+               
+                
+                Divider().padding(.leading, 20)
+                
+                // 카카오 로그인 버튼
+                loginTypeButton(
+                    title: "카카오 로그인 사용 중",
+                    isSelected: store.currentLoginType == .kakao,
+                    action: { store.send(.selectLoginType(.kakao)) }
+                )
+            }
+            .background(Color.white)
+            .cornerRadius(8)
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
             
-            Text("계정 관리 화면")
-                .font(.title2)
+            // 로그아웃 버튼
+            Button(action: {
+                store.send(.logoutButtonTapped)
+            }) {
+                HStack {
+                    Text("로그아웃")
+                        .customFont(.body2m)
+                        .foregroundColor(.main400)
+                    
+                    Spacer()
+                    
+                    Image(.icArrowRightGray400)
+                }
+                .padding(.horizontal, 20)
+                .frame(height: 50)
+            }
+            .background(Color.white)
+            .cornerRadius(8)
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            
+            // 탈퇴하기 버튼
+            Button(action: {
+                store.send(.withdrawButtonTapped)
+            }) {
+                HStack {
+                    Text("탈퇴하기")
+                        .customFont(.body2m)
+                        .foregroundColor(.gray600)
+                    
+                    Spacer()
+                    
+                    Image(.icArrowRightGray400)
+                }
+                .padding(.horizontal, 20)
+                .frame(height: 50)
+            }
+            .background(Color.white)
+            .cornerRadius(8)
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
             
             Spacer()
         }
-        .background(Color.white)
+        .background(Color.gray0)
         .navigationBarHidden(true)
     }
+    
+    private func loginTypeButton(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .customFont(.body2m)
+                    .foregroundColor(.gray700)
+                
+                Spacer()
+                
+                if isSelected {
+                    Circle()
+                        .fill(Color.main400)
+                        .frame(width: 20, height: 20)
+                }
+            }
+            .padding(.horizontal, 20)
+            .frame(height: 50)
+            .contentShape(Rectangle())
+        }
+    }
+}
+
+#Preview {
+    AccountManagementView(
+        store: Store(initialState: .initialState) {
+            AccountManagementFeature()
+        }
+    )
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
@@ -37,7 +37,7 @@ struct AccountManagementView: View {
                 
                 Spacer()
                 
-                Text("카카오 로그인 사용 중")
+                Text(loginTypeText)
                     .padding(.trailing, 20)
                     .customFont(.body2b)
                     .foregroundStyle(.gray600)
@@ -65,7 +65,6 @@ struct AccountManagementView: View {
             .background(Color.white)
             .padding(.top, 10)
             
-            // 탈퇴하기 버튼
             Button(action: {
                 store.send(.withdrawButtonTapped)
             }) {
@@ -90,6 +89,31 @@ struct AccountManagementView: View {
         }
         .background(Color.gray0)
         .navigationBarHidden(true)
+        .alert(
+            "로그아웃",
+            isPresented: .init(
+                get: { store.logoutAlert != nil },
+                set: { if !$0 { store.send(.cancelLogout) } }
+            ),
+            actions: {
+                Button("취소", role: .cancel) {
+                    store.send(.cancelLogout)
+                }
+                Button("확인", role: .destructive) {
+                    store.send(.confirmLogout)
+                }
+            },
+            message: { Text("정말 로그아웃 하시겠습니까?") }
+        )
+    }
+    
+    private var loginTypeText: String {
+        switch store.currentLoginType {
+        case .apple:
+            return "애플 로그인 사용 중"
+        case .kakao:
+            return "카카오 로그인 사용 중"
+        }
     }
 }
 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
@@ -17,34 +17,34 @@ struct AccountManagementView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            // 네비게이션 바
             CustomNavigationBar(
                 style: .detail,
                 title: "계정 관리",
                 onBackTapped: {
                     store.send(.routeToPreviousScreen)
                 }
-            )
+            ).background(Color.white)
             
-            // 로그인 타입 섹션
-            VStack(spacing: 0) {
-               
+            Divider()
+                .frame(height: 1)
+                .foregroundStyle(.gray0)
+            
+            HStack(spacing: 0) {
+                Text("간편 로그인")
+                    .padding(.leading, 20)
+                    .customFont(.body2m)
+                    .foregroundStyle(.gray700)
                 
-                Divider().padding(.leading, 20)
+                Spacer()
                 
-                // 카카오 로그인 버튼
-                loginTypeButton(
-                    title: "카카오 로그인 사용 중",
-                    isSelected: store.currentLoginType == .kakao,
-                    action: { store.send(.selectLoginType(.kakao)) }
-                )
+                Text("카카오 로그인 사용 중")
+                    .padding(.trailing, 20)
+                    .customFont(.body2b)
+                    .foregroundStyle(.gray600)
             }
+            .frame(height: 48.adjustedH)
             .background(Color.white)
-            .cornerRadius(8)
-            .padding(.horizontal, 16)
-            .padding(.top, 16)
             
-            // 로그아웃 버튼
             Button(action: {
                 store.send(.logoutButtonTapped)
             }) {
@@ -52,18 +52,18 @@ struct AccountManagementView: View {
                     Text("로그아웃")
                         .customFont(.body2m)
                         .foregroundColor(.main400)
+                        .padding(.leading, 20)
                     
                     Spacer()
                     
                     Image(.icArrowRightGray400)
+                        .padding(.trailing, 20)
                 }
-                .padding(.horizontal, 20)
-                .frame(height: 50)
+                .frame(maxWidth: .infinity)
+                .frame(height: 48.adjustedH)
             }
             .background(Color.white)
-            .cornerRadius(8)
-            .padding(.horizontal, 16)
-            .padding(.top, 16)
+            .padding(.top, 10)
             
             // 탈퇴하기 버튼
             Button(action: {
@@ -72,45 +72,24 @@ struct AccountManagementView: View {
                 HStack {
                     Text("탈퇴하기")
                         .customFont(.body2m)
-                        .foregroundColor(.gray600)
+                        .foregroundColor(.gray500)
+                        .padding(.leading, 20)
                     
                     Spacer()
                     
                     Image(.icArrowRightGray400)
+                        .padding(.trailing, 20)
                 }
-                .padding(.horizontal, 20)
-                .frame(height: 50)
+                .frame(maxWidth: .infinity)
+                .frame(height: 48.adjustedH)
             }
             .background(Color.white)
-            .cornerRadius(8)
-            .padding(.horizontal, 16)
-            .padding(.top, 16)
+            .padding(.top, 10)
             
             Spacer()
         }
         .background(Color.gray0)
         .navigationBarHidden(true)
-    }
-    
-    private func loginTypeButton(title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack {
-                Text(title)
-                    .customFont(.body2m)
-                    .foregroundColor(.gray700)
-                
-                Spacer()
-                
-                if isSelected {
-                    Circle()
-                        .fill(Color.main400)
-                        .frame(width: 20, height: 20)
-                }
-            }
-            .padding(.horizontal, 20)
-            .frame(height: 50)
-            .contentShape(Rectangle())
-        }
     }
 }
 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/AccountManagementView.swift
@@ -16,95 +16,95 @@ struct AccountManagementView: View {
     }
     
     var body: some View {
-        VStack(spacing: 0) {
-            CustomNavigationBar(
-                style: .detail,
-                title: "계정 관리",
-                onBackTapped: {
-                    store.send(.routeToPreviousScreen)
+        ZStack {
+            VStack(spacing: 0) {
+                CustomNavigationBar(
+                    style: .detail,
+                    title: "계정 관리",
+                    onBackTapped: {
+                        store.send(.routeToPreviousScreen)
+                    }
+                ).background(Color.white)
+                
+                Divider()
+                    .frame(height: 1)
+                    .foregroundStyle(.gray0)
+                
+                HStack(spacing: 0) {
+                    Text("간편 로그인")
+                        .padding(.leading, 20)
+                        .customFont(.body2m)
+                        .foregroundStyle(.gray700)
+                    
+                    Spacer()
+                    
+                    Text(loginTypeText)
+                        .padding(.trailing, 20)
+                        .customFont(.body2b)
+                        .foregroundStyle(.gray600)
                 }
-            ).background(Color.white)
-            
-            Divider()
-                .frame(height: 1)
-                .foregroundStyle(.gray0)
-            
-            HStack(spacing: 0) {
-                Text("간편 로그인")
-                    .padding(.leading, 20)
-                    .customFont(.body2m)
-                    .foregroundStyle(.gray700)
+                .frame(height: 48.adjustedH)
+                .background(Color.white)
+                
+                Button(action: {
+                    store.send(.logoutButtonTapped)
+                }) {
+                    HStack {
+                        Text("로그아웃")
+                            .customFont(.body2m)
+                            .foregroundColor(.main400)
+                            .padding(.leading, 20)
+                        
+                        Spacer()
+                        
+                        Image(.icArrowRightGray400)
+                            .padding(.trailing, 20)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 48.adjustedH)
+                }
+                .background(Color.white)
+                .padding(.top, 10)
+                
+                Button(action: {
+                    store.send(.withdrawButtonTapped)
+                }) {
+                    HStack {
+                        Text("탈퇴하기")
+                            .customFont(.body2m)
+                            .foregroundColor(.gray500)
+                            .padding(.leading, 20)
+                        
+                        Spacer()
+                        
+                        Image(.icArrowRightGray400)
+                            .padding(.trailing, 20)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 48.adjustedH)
+                }
+                .background(Color.white)
+                .padding(.top, 10)
                 
                 Spacer()
-                
-                Text(loginTypeText)
-                    .padding(.trailing, 20)
-                    .customFont(.body2b)
-                    .foregroundStyle(.gray600)
             }
-            .frame(height: 48.adjustedH)
-            .background(Color.white)
+            .background(Color.gray0)
+            .navigationBarHidden(true)
             
-            Button(action: {
-                store.send(.logoutButtonTapped)
-            }) {
-                HStack {
-                    Text("로그아웃")
-                        .customFont(.body2m)
-                        .foregroundColor(.main400)
-                        .padding(.leading, 20)
-                    
-                    Spacer()
-                    
-                    Image(.icArrowRightGray400)
-                        .padding(.trailing, 20)
-                }
-                .frame(maxWidth: .infinity)
-                .frame(height: 48.adjustedH)
+            if store.logoutAlert != nil {
+                CustomAlertView(
+                    title: "로그아웃 하시겠습니까?",
+                    cancelTitle: "아니요",
+                    confirmTitle: "네",
+                    cancelAction: {
+                        store.send(.cancelLogout)
+                    },
+                    confirmAction: {
+                        store.send(.confirmLogout)
+                    }
+                )
             }
-            .background(Color.white)
-            .padding(.top, 10)
-            
-            Button(action: {
-                store.send(.withdrawButtonTapped)
-            }) {
-                HStack {
-                    Text("탈퇴하기")
-                        .customFont(.body2m)
-                        .foregroundColor(.gray500)
-                        .padding(.leading, 20)
-                    
-                    Spacer()
-                    
-                    Image(.icArrowRightGray400)
-                        .padding(.trailing, 20)
-                }
-                .frame(maxWidth: .infinity)
-                .frame(height: 48.adjustedH)
-            }
-            .background(Color.white)
-            .padding(.top, 10)
-            
-            Spacer()
         }
-        .background(Color.gray0)
-        .navigationBarHidden(true)
-        .alert(
-            "로그아웃",
-            isPresented: .init(
-                get: { store.logoutAlert != nil },
-                set: { if !$0 { store.send(.cancelLogout) } }
-            ),
-            actions: {
-                Button("취소", role: .cancel) {
-                    store.send(.cancelLogout)
-                }
-                Button("확인", role: .destructive) {
-                    store.send(.confirmLogout)
-                }
-            },
-            message: { Text("정말 로그아웃 하시겠습니까?") }
-        )
     }
     
     private var loginTypeText: String {

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/CustomAlertView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/CustomAlertView.swift
@@ -1,0 +1,63 @@
+//
+//  CustomAlertView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 5/3/25.
+//
+
+import SwiftUI
+
+struct CustomAlertView: View {
+    let title: String
+    let cancelTitle: String
+    let confirmTitle: String
+    let cancelAction: () -> Void
+    let confirmAction: () -> Void
+    
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.6)
+                .ignoresSafeArea()
+            
+            VStack(spacing: 32) {
+                Text(title)
+                    .customFont(.body1b)
+                    .foregroundColor(.spoonBlack)
+                    .padding(.top, 40)
+                
+                HStack(spacing: 12) {
+                    // 취소 버튼
+                    Button(action: cancelAction) {
+                        Text(cancelTitle)
+                            .customFont(.body2b)
+                            .foregroundColor(.gray600)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48.adjustedH)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(Color.gray0)
+                            )
+                    }
+                    
+                    // 확인 버튼
+                    Button(action: confirmAction) {
+                        Text(confirmTitle)
+                            .customFont(.body2b)
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 44.adjustedH)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(Color.spoonBlack)
+                            )
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 20)
+            }
+            .frame(width: UIScreen.main.bounds.width - 40)
+            .background(Color.white)
+            .cornerRadius(16)
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/CustomAlertView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/CustomAlertView.swift
@@ -55,7 +55,7 @@ struct CustomAlertView: View {
                 .padding(.horizontal, 20)
                 .padding(.bottom, 20)
             }
-            .frame(width: UIScreen.main.bounds.width - 40)
+            .frame(width: UIScreen.main.bounds.width - 40.adjustedH)
             .background(Color.white)
             .cornerRadius(16)
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/LogOut/LogoutFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/LogOut/LogoutFeature.swift
@@ -1,0 +1,74 @@
+//
+//  LogoutFeature.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 5/3/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct LogoutFeature {
+    @ObservableState
+    struct State: Equatable {
+        static let initialState = State()
+        
+        var isLoggingOut: Bool = false
+        var showLogoutAlert: Bool = false
+    }
+    
+    enum Action {
+        case routeToPreviousScreen
+        case logoutButtonTapped
+        case confirmLogout
+        case cancelLogout
+        case logoutResult(TaskResult<Bool>)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .routeToPreviousScreen:
+                return .none
+                
+            case .logoutButtonTapped:
+                state.showLogoutAlert = true
+                return .none
+                
+            case .confirmLogout:
+                state.showLogoutAlert = false
+                state.isLoggingOut = true
+                
+                // 실제 로그아웃 로직 호출
+                return .run { send in
+                    do {
+                        // API 호출 또는 로그아웃 처리 로직
+                        // 예: try await userService.logout()
+                        try await Task.sleep(nanoseconds: 1_000_000_000) // 1초 지연 (시뮬레이션)
+                        await send(.logoutResult(.success(true)))
+                    } catch {
+                        await send(.logoutResult(.failure(error)))
+                    }
+                }
+                
+            case .cancelLogout:
+                state.showLogoutAlert = false
+                return .none
+                
+            case let .logoutResult(.success(isSuccess)):
+                state.isLoggingOut = false
+                if isSuccess {
+                    // 로그아웃 성공 시 로그인 화면으로 이동하는 액션
+                    // TODO: 로그인 화면으로 이동 구현
+                }
+                return .none
+                
+            case let .logoutResult(.failure(error)):
+                state.isLoggingOut = false
+                print("로그아웃 실패: \(error.localizedDescription)")
+                return .none
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/LogOut/LogoutView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/LogOut/LogoutView.swift
@@ -80,7 +80,6 @@ struct LogoutView: View {
             .padding(.horizontal, 16)
         }
         .background(Color.white)
-        .navigationBarHidden(true)
         .overlay {
             if store.isLoggingOut {
                 ProgressView()

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/LogOut/LogoutView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/LogOut/LogoutView.swift
@@ -1,0 +1,101 @@
+//
+//  LogoutView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 5/3/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct LogoutView: View {
+    @Bindable private var store: StoreOf<LogoutFeature>
+    
+    init(store: StoreOf<LogoutFeature>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            CustomNavigationBar(
+                style: .detail,
+                title: "로그아웃",
+                onBackTapped: {
+                    store.send(.routeToPreviousScreen)
+                }
+            )
+            
+            VStack(spacing: 20) {
+                Spacer()
+                
+                
+                Text("로그아웃 하시겠습니까?")
+                    .customFont(.title3b)
+                    .foregroundStyle(.spoonBlack)
+                
+                Text("로그아웃 시 스푸니 서비스 이용이 제한됩니다.")
+                    .customFont(.body2m)
+                    .foregroundStyle(.gray500)
+                    .multilineTextAlignment(.center)
+                
+                HStack(spacing: 16) {
+                    // 취소 버튼
+                    Button(action: {
+                        store.send(.routeToPreviousScreen)
+                    }) {
+                        Text("취소")
+                            .customFont(.body2sb)
+                            .foregroundStyle(.gray600)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color.white)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 8)
+                                            .stroke(Color.gray200, lineWidth: 1)
+                                    )
+                            )
+                    }
+                    
+                    // 로그아웃 버튼
+                    Button(action: {
+                        store.send(.logoutButtonTapped)
+                    }) {
+                        Text("로그아웃")
+                            .customFont(.body2sb)
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                            )
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 40)
+                
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+        }
+        .background(Color.white)
+        .navigationBarHidden(true)
+        .overlay {
+            if store.isLoggingOut {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color.black.opacity(0.3))
+            }
+        }
+       
+    }
+}
+
+#Preview {
+    LogoutView(
+        store: Store(initialState: .initialState) {
+            LogoutFeature()
+        }
+    )
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawFeature.swift
@@ -1,0 +1,80 @@
+//
+//  WithdrawFeature.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 5/3/25.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct WithdrawFeature {
+    @ObservableState
+    struct State: Equatable {
+        static let initialState = State()
+        
+        var isWithdrawing: Bool = false
+        var showWithdrawAlert: Bool = false
+        var isAgreed: Bool = false
+    }
+    
+    enum Action {
+        case routeToPreviousScreen
+        case toggleAgreement
+        case withdrawButtonTapped
+        case confirmWithdraw
+        case cancelWithdraw
+        case withdrawResult(TaskResult<Bool>)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .routeToPreviousScreen:
+                return .none
+                
+            case .toggleAgreement:
+                state.isAgreed.toggle()
+                return .none
+                
+            case .withdrawButtonTapped:
+                state.showWithdrawAlert = true
+                return .none
+                
+            case .confirmWithdraw:
+                state.showWithdrawAlert = false
+                state.isWithdrawing = true
+                
+                // 실제 회원 탈퇴 로직 호출
+                return .run { send in
+                    do {
+                        // API 호출 또는 회원 탈퇴 처리 로직
+                        // 예: try await userService.withdraw()
+                        try await Task.sleep(nanoseconds: 1_000_000_000) // 1초 지연 (시뮬레이션)
+                        await send(.withdrawResult(.success(true)))
+                    } catch {
+                        await send(.withdrawResult(.failure(error)))
+                    }
+                }
+                
+            case .cancelWithdraw:
+                state.showWithdrawAlert = false
+                return .none
+                
+            case let .withdrawResult(.success(isSuccess)):
+                state.isWithdrawing = false
+                if isSuccess {
+                    // 탈퇴 성공 시 로그인 화면으로 이동하는 액션
+                    // TODO: 로그인 화면으로 이동 구현
+                }
+                return .none
+                
+            case let .withdrawResult(.failure(error)):
+                state.isWithdrawing = false
+                print("회원 탈퇴 실패: \(error.localizedDescription)")
+                return .none
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawView.swift
@@ -1,0 +1,39 @@
+//
+//  WithdrawView.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 5/3/25.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct WithdrawView: View {
+    @Bindable private var store: StoreOf<WithdrawFeature>
+    
+    init(store: StoreOf<WithdrawFeature>) {
+        self.store = store
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            CustomNavigationBar(
+                style: .detail,
+                title: "회원 탈퇴",
+                onBackTapped: {
+                    store.send(.routeToPreviousScreen)
+                }
+            )
+            
+            
+        }
+    }
+}
+
+#Preview {
+    WithdrawView(
+        store: Store(initialState: .initialState) {
+            WithdrawFeature()
+        }
+    )
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawView.swift
@@ -22,8 +22,11 @@ struct WithdrawView: View {
                 title: "회원 탈퇴",
                 onBackTapped: {
                     store.send(.routeToPreviousScreen)
+                    
                 }
+            )
         }
+        
     }
 }
 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+
 import ComposableArchitecture
 
 struct WithdrawView: View {
@@ -17,16 +18,69 @@ struct WithdrawView: View {
     
     var body: some View {
         VStack(spacing: 0) {
+
             CustomNavigationBar(
                 style: .detail,
                 title: "회원 탈퇴",
                 onBackTapped: {
                     store.send(.routeToPreviousScreen)
-                    
                 }
-            )
+            ).background(Color.white)
+            Divider()
+                .frame(height: 1)
+                .foregroundStyle(.gray100)
+            
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+
+                    bulletPointList
+
+                    HStack {
+                        Button(action: {
+                            store.send(.toggleAgreement)
+                        }) {
+                            Image(store.isAgreed ? "ic_checkboxfilled_main" : "ic_checkboxempty_gray400")
+                                .resizable()
+                                .frame(width: 24, height: 24)
+                        }
+                        
+                        Text("위 유의사항을 확인했습니다.")
+                            .customFont(.body2m)
+                            .foregroundColor(.spoonBlack)
+                            .padding(.leading, 8)
+                        
+                        Spacer()
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 8)
+            
+                    SpoonyButton(
+                        style: .primary,
+                        size: .xlarge,
+                        title: "탈퇴하기",
+                        disabled: .init(get: { !store.isAgreed }, set: { _ in })
+                    ) {
+                        if store.isAgreed {
+                            store.send(.performWithdraw)
+                        }
+                    }
+                    .padding(.top, 12)
+                    .padding(.horizontal, 20)
+                    
+                    Spacer()
+                }
+            }
         }
-        
+        .background(Color.white)
+    }
+    
+    private var bulletPointList: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            BulletPointText(text: "회원 탈퇴 시, 즉시 탈퇴 처리되며 서비스 이용이 불가해요.")
+            BulletPointText(text: "탈퇴 시 모든 정보가 사라지며, 회원님의 소중한 정보를 되살릴 수 없어요.")
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 24)
     }
 }
 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Setting/AccountManagement/withdraw/WithdrawView.swift
@@ -23,9 +23,6 @@ struct WithdrawView: View {
                 onBackTapped: {
                     store.send(.routeToPreviousScreen)
                 }
-            )
-            
-            
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #268 

## 📄 작업 내용
- 회원탈퇴뷰 구현
- 로그아웃뷰 구현
- 내부 TCA 로직 수현


|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/3241e9d9-d966-4cb1-a1e3-df7a5bf4eda1" width ="250"> | <img src = "" width ="250"> |


## 👀 기타 더 이야기해볼 점
하 API 언제붙임