### PR TITLE
[Fix/#320] 고장난지도뷰고치기

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Network/Auth/UserManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/UserManager.swift
@@ -96,19 +96,6 @@ final class UserManager {
     func updateLastVisitDate() {
         lastAppVisitDate = Calendar.current.startOfDay(for: Date())
     }
-    
-    func clearAllUserDefaults() {
-        UserDefaultsKeys.allCases.forEach { key in
-            UserDefaults.standard.removeObject(forKey: key.rawValue)
-        }
-        
-        userId = nil
-        isTooltipPresented = nil
-        recentSearches = nil
-        exploreUserRecentSearches = nil
-        exploreReviewRecentSearches = nil
-        lastAppVisitDate = nil
-    }
 }
 
 enum SearchType {

--- a/Spoony-iOS/Spoony-iOS/Network/Base/Providers.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Base/Providers.swift
@@ -18,6 +18,7 @@ struct Providers {
     static let myPageProvider = MoyaProvider<MyPageTargetType>.init(withAuth: true)
     static let imageProvider = MoyaProvider<ImageLoadTargetType>.init(withAuth: true)
     static let followProvider = MoyaProvider<FollowTargetType>.init(withAuth: true)
+    static let spoonDrawProvider = MoyaProvider<SpoonDrawTargetType>.init(withAuth: true)
 }
 
 extension MoyaProvider {

--- a/Spoony-iOS/Spoony-iOS/Network/DependencyKey/SpoonDrawServiceKey.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/DependencyKey/SpoonDrawServiceKey.swift
@@ -1,0 +1,13 @@
+//
+//  SpoonDrawServiceKey.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 5/21/25.
+//
+
+import Foundation
+import Dependencies
+
+enum SpoonDrawServiceKey: DependencyKey {
+    static let liveValue: SpoonDrawServiceProtocol = SpoonDrawService()
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Model/SpoonDrawResponse.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Model/SpoonDrawResponse.swift
@@ -1,0 +1,31 @@
+//
+//  SpoonModels.swift
+//  Spoony-iOS
+//
+//  Created on 5/20/25.
+//
+
+import Foundation
+
+// 스푼 뽑기 응답 모델
+struct SpoonDrawResponse: Codable, Equatable {
+    let drawId: Int
+    let spoonType: SpoonType
+    let localDate: String
+    let weekStartDate: String
+    let createdAt: String
+}
+
+// 스푼 타입 모델
+struct SpoonType: Codable, Equatable {
+    let spoonTypeId: Int
+    let spoonName: String
+    let spoonAmount: Int
+    let probability: Double
+    let spoonImage: String
+}
+
+// 이미 있는 스푼 카운트 응답 모델과 이름을 다르게 설정 (충돌 해결)
+struct SpoonCountResponse: Codable {
+    let spoonAmount: Int
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Model/SpoonDrawResponse.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Model/SpoonDrawResponse.swift
@@ -7,7 +7,22 @@
 
 import Foundation
 
-// 스푼 뽑기 응답 모델
+struct SpoonDrawResponseWrapper: Codable, Equatable {
+    let success: Bool
+    let data: SpoonDrawData?
+    let error: APIError?
+    
+    struct SpoonDrawData: Codable, Equatable {
+        let spoonDrawResponseDTOList: [SpoonDrawResponse]
+        let spoonBalance: Int
+        let weeklyBalance: Int
+    }
+    
+    struct APIError: Codable, Equatable {
+        let message: String
+    }
+}
+
 struct SpoonDrawResponse: Codable, Equatable {
     let drawId: Int
     let spoonType: SpoonType
@@ -16,7 +31,6 @@ struct SpoonDrawResponse: Codable, Equatable {
     let createdAt: String
 }
 
-// 스푼 타입 모델
 struct SpoonType: Codable, Equatable {
     let spoonTypeId: Int
     let spoonName: String
@@ -25,7 +39,6 @@ struct SpoonType: Codable, Equatable {
     let spoonImage: String
 }
 
-// 이미 있는 스푼 카운트 응답 모델과 이름을 다르게 설정 (충돌 해결)
 struct SpoonCountResponse: Codable {
     let spoonAmount: Int
 }

--- a/Spoony-iOS/Spoony-iOS/Network/Service/Service.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Service/Service.swift
@@ -1,8 +1,0 @@
-//
-//  Service.swift
-//  SpoonMe
-//
-//  Created by 이지훈 on 1/2/25.
-//
-
-import Foundation

--- a/Spoony-iOS/Spoony-iOS/Network/Service/SpoonDrawService.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Service/SpoonDrawService.swift
@@ -1,0 +1,62 @@
+//
+//  SpoonDrawService.swift
+//  Spoony-iOS
+//
+//  Created on 5/21/25.
+//
+
+import Foundation
+import Moya
+
+protocol SpoonDrawServiceProtocol {
+    func fetchSpoonDrawInfo() async throws -> SpoonDrawResponseWrapper
+    func drawSpoon() async throws -> SpoonDrawResponse
+}
+
+final class SpoonDrawService: SpoonDrawServiceProtocol {
+    private let provider = MoyaProvider<SpoonDrawTargetType>.init(plugins: [SpoonyLoggingPlugin()])
+    
+    func fetchSpoonDrawInfo() async throws -> SpoonDrawResponseWrapper {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(.getSpoonDrawInfo) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let responseDto = try response.map(SpoonDrawResponseWrapper.self)
+                        continuation.resume(returning: responseDto)
+                    } catch {
+                        print("스푼 정보 디코딩 에러: \(error)")
+                        continuation.resume(throwing: SNError.decodeError)
+                    }
+                case .failure(let error):
+                    print("스푼 정보 API 에러: \(error)")
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+    
+    func drawSpoon() async throws -> SpoonDrawResponse {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(.drawSpoon) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let responseDto = try response.map(BaseResponse<SpoonDrawResponse>.self)
+                        guard let data = responseDto.data else {
+                            continuation.resume(throwing: SNError.noData)
+                            return
+                        }
+                        continuation.resume(returning: data)
+                    } catch {
+                        print("스푼 뽑기 디코딩 에러: \(error)")
+                        continuation.resume(throwing: SNError.decodeError)
+                    }
+                case .failure(let error):
+                    print("스푼 뽑기 API 에러: \(error)")
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Network/TargetType/HomeTargetType.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/TargetType/HomeTargetType.swift
@@ -15,6 +15,7 @@ enum HomeTargetType {
     case getSearchResultList(query: String)
     case getSearchResultLocation(locationId: Int)
     case getLocationList(locationId: Int)
+    case drawSpoon  
 }
 
 extension HomeTargetType: TargetType {
@@ -40,28 +41,33 @@ extension HomeTargetType: TargetType {
             return "/post/zzim/location/\(locationId)"
         case .getLocationList(let locationId):
             return "/post/zzim/location/\(locationId)"
+        case .drawSpoon:
+            return "/spoon/draw"
         }
     }
     
     var method: Moya.Method {
         switch self {
         case .getSpoonCount,
-                .getMapList,
-                .getMapFocus,
-                .getSearchResultList,
-                .getLocationList,
-                .getSearchResultLocation:
+             .getMapList,
+             .getMapFocus,
+             .getSearchResultList,
+             .getLocationList,
+             .getSearchResultLocation:
             return .get
+        case .drawSpoon:
+            return .post
         }
     }
     
     var task: Moya.Task {
         switch self {
         case .getSpoonCount,
-                .getMapList,
-                .getMapFocus,
-                .getLocationList,
-                .getSearchResultLocation:
+             .getMapList,
+             .getMapFocus,
+             .getLocationList,
+             .getSearchResultLocation,
+             .drawSpoon:
             return .requestPlain
             
         case .getSearchResultList(let query):
@@ -73,11 +79,6 @@ extension HomeTargetType: TargetType {
     }
     
     var headers: [String: String]? {
-        switch self {
-        case .getSpoonCount:
-            return Config.defaultHeader
-        default:
-            return HeaderType.auth.value
-        }
+        return HeaderType.auth.value
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Network/TargetType/SpoonDrawTargetType.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/TargetType/SpoonDrawTargetType.swift
@@ -1,0 +1,50 @@
+//
+//  SpoonDrawTargetType.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 5/21/25.
+//
+
+import Foundation
+import Moya
+
+enum SpoonDrawTargetType {
+    case getSpoonDrawInfo
+    case drawSpoon
+}
+
+extension SpoonDrawTargetType: TargetType {
+    var baseURL: URL {
+        guard let url = URL(string: Config.baseURL) else {
+            fatalError("baseURL could not be configured")
+        }
+        return url
+    }
+    
+    var path: String {
+        switch self {
+        case .getSpoonDrawInfo, .drawSpoon:
+            return "/spoon/draw"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getSpoonDrawInfo:
+            return .get
+        case .drawSpoon:
+            return .post
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getSpoonDrawInfo, .drawSpoon:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String: String]? {
+        return HeaderType.auth.value
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyDraw/SpoonDrawPopupView.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyDraw/SpoonDrawPopupView.swift
@@ -44,7 +44,7 @@ struct SpoonDrawPopupView: View {
                     .font(.title1)
                     .padding(.top, 0)
                 
-                Text("'스푼 뽑기' 버튼을 누르면\n오늘의 스폰을 획득할 수 있어요.")
+                Text("'스푼 뽑기' 버튼을 누르면\n오늘의 스푼을 획득할 수 있어요.")
                     .font(.body2sb)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.gray600)
@@ -92,7 +92,7 @@ struct SpoonDrawPopupView: View {
                                 .font(.title3sb)
                                 .foregroundColor(.gray600)
                             
-                            Text(error.contains("이미 스폰 뽑기를 진행한 사용자")
+                            Text(error.contains("이미 스푼 뽑기를 진행한 사용자")
                                  ? "오늘 이미 스푼을 뽑았어요!\n내일 다시 시도해주세요."
                                  : "스푼 뽑기에 실패했어요.\n다시 시도해주세요.")
                                 .font(.body2m)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyDraw/SpoonDrawPopupView.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyDraw/SpoonDrawPopupView.swift
@@ -11,18 +11,21 @@ struct SpoonDrawPopupView: View {
     @Binding var isPresented: Bool
     var onDrawSpoon: () -> Void
     
-    @State private var isLoading = false
-    @State private var drawnSpoons: Int? = nil
+    let isDrawing: Bool
+    let drawnSpoon: SpoonDrawResponse?
+    let errorMessage: String?
     
     var body: some View {
         ZStack {
-            Color.black.opacity(0.4)
-                .ignoresSafeArea(.all)
-                .onTapGesture {
-                    if drawnSpoons != nil {
-                        isPresented = false
+            if isPresented {
+                Color.black.opacity(0.4)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        if !isDrawing && (drawnSpoon != nil || errorMessage != nil) {
+                            isPresented = false
+                        }
                     }
-                }
+            }
             
             VStack(spacing: 0) {
                 // 닫기 버튼 영역
@@ -41,46 +44,82 @@ struct SpoonDrawPopupView: View {
                     .font(.title1)
                     .padding(.top, 0)
                 
-                Text("'스푼 뽑기' 버튼을 누르면\n오늘의 스푼을 획득할 수 있어요.")
+                Text("'스푼 뽑기' 버튼을 누르면\n오늘의 스폰을 획득할 수 있어요.")
                     .font(.body2sb)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.gray600)
                     .padding(.top, 16)
                 
+                // 로띠 영역 또는 스푼 이미지 영역
                 ZStack {
                     Rectangle()
-                        .fill(Color.gray100)
                         .aspectRatio(1, contentMode: .fit)
                         .padding(.horizontal, 36)
                         .padding(.vertical, 20)
-                    
-                    if let spoons = drawnSpoons {
+                        .foregroundColor(.gray100)
+                        
+                    if isDrawing {
+                        // 로딩 상태
+                        VStack(spacing: 16) {
+                            ProgressView()
+                                .scaleEffect(2.0)
+                            
+                            Text("스푼을 뽑는 중...")
+                                .font(.body1sb)
+                                .foregroundColor(.gray500)
+                        }
+                    } else if let spoon = drawnSpoon {
+                        // 스푼 뽑기 성공 상태
                         VStack {
                             Image("ic_spoon_main")
                                 .resizable()
+                                .aspectRatio(contentMode: .fit)
                                 .frame(width: 80, height: 80)
                             
-                            Text("+\(spoons) 스푼")
+                            Text("+\(spoon.spoonType.spoonAmount) 스푼")
                                 .font(.title3sb)
                                 .foregroundStyle(.main400)
                                 .padding(.top, 16)
                         }
-                    } else if isLoading {
-                        ProgressView()
-                            .scaleEffect(2.0)
+                    } else if let error = errorMessage {
+                        // 에러 상태
+                        VStack(spacing: 12) {
+                            Image(systemName: "exclamationmark.circle")
+                                .font(.system(size: 40))
+                                .foregroundColor(.gray400)
+                            
+                            Text("스푼 뽑기 실패")
+                                .font(.title3sb)
+                                .foregroundColor(.gray600)
+                            
+                            Text(error.contains("이미 스폰 뽑기를 진행한 사용자")
+                                 ? "오늘 이미 스푼을 뽑았어요!\n내일 다시 시도해주세요."
+                                 : "스푼 뽑기에 실패했어요.\n다시 시도해주세요.")
+                                .font(.body2m)
+                                .multilineTextAlignment(.center)
+                                .foregroundColor(.gray400)
+                        }
+                    } else {
+                        // 초기 상태
+                        Image("ic_spoon_main")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 80, height: 80)
+                            .opacity(0.6)
                     }
                 }
             
                 SpoonyButton(
                     style: .primary,
                     size: .medium,
-                    title: drawnSpoons != nil ? "확인" : "스푼 뽑기",
-                    disabled: .constant(isLoading)
+                    title: getButtonTitle(),
+                    isIcon: false,
+                    disabled: .constant(isDrawing)
                 ) {
-                    if drawnSpoons != nil {
+                    if drawnSpoon != nil || errorMessage != nil {
                         isPresented = false
-                    } else {
-                        drawSpoon()
+                    } else if !isDrawing {
+                        onDrawSpoon()
                     }
                 }
                 .padding(.horizontal, 20)
@@ -94,19 +133,25 @@ struct SpoonDrawPopupView: View {
         }
     }
     
-    private func drawSpoon() {
-        isLoading = true
-        
-        //TODO: 스푼 뽑기 로직
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            // 1~5개 사이 랜덤 스푼
-            self.drawnSpoons = Int.random(in: 1...5)
-            self.isLoading = false
-            self.onDrawSpoon()
+    private func getButtonTitle() -> String {
+        if drawnSpoon != nil {
+            return "확인"
+        } else if errorMessage != nil {
+            return "닫기"
+        } else if isDrawing {
+            return "뽑는 중..."
+        } else {
+            return "스푼 뽑기"
         }
     }
 }
 
 #Preview {
-    SpoonDrawPopupView(isPresented: .constant(true), onDrawSpoon: {})
+    SpoonDrawPopupView(
+        isPresented: .constant(true),
+        onDrawSpoon: {},
+        isDrawing: false,
+        drawnSpoon: nil,
+        errorMessage: nil
+    )
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Extension/DependencyValues+.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Extension/DependencyValues+.swift
@@ -52,4 +52,9 @@ extension DependencyValues {
         get { self[ReportServiceKey.self] }
         set { self[ReportServiceKey.self] = newValue }
     }
+    
+    var spoonDrawService: SpoonDrawServiceProtocol {
+        get { self[SpoonDrawServiceKey.self] }
+        set { self[SpoonDrawServiceKey.self] = newValue }
+    }
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
@@ -41,6 +41,9 @@ struct Home: View {
                     style: .searchContent,
                     searchText: $store.searchText.sending(\.setSearchText),
                     spoonCount: store.spoonCount,
+                    spoonTapped: {
+                        store.send(.setShowDailySpoonPopup(true))
+                    },
                     tappedAction: {
                         store.send(.routToSearchScreen)
                     }
@@ -186,7 +189,10 @@ struct Home: View {
                     ),
                     onDrawSpoon: {
                         store.send(.drawDailySpoon)
-                    }
+                    },
+                    isDrawing: store.isDrawingSpoon,
+                    drawnSpoon: store.drawnSpoon,
+                    errorMessage: store.spoonDrawError
                 )
             }
         }
@@ -214,10 +220,4 @@ class LocationManagerDelegate: NSObject, CLLocationManagerDelegate, ObservableOb
             onLocationUpdate(location)
         }
     }
-}
-
-#Preview {
-    Home(store: Store(initialState: .initialState) {
-        MapFeature()
-    })
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Attendance/AttendanceFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Attendance/AttendanceFeature.swift
@@ -14,7 +14,7 @@ struct AttendanceFeature {
     @ObservableState
     struct State: Equatable {
         var selectedDays: Set<String> = ["월", "화"]
-        let dateRange = "2025. 03. 24 (월) ~ 2025. 03. 30 (일)"
+        let dateRange: String
         let weekdays = ["월", "화", "수", "목", "금", "토", "일"]
         let noticeItems = [
             "출석체크는 매일 자정에 리셋 되어요",
@@ -22,9 +22,38 @@ struct AttendanceFeature {
             "신규 가입 시 5개의 스푼을 적립해 드려요"
         ]
         
-        static let initialState = State()
+        static let initialState = State(
+            dateRange: Self.getCurrentWeekDateRange()
+        )
+        
+        static func getCurrentWeekDateRange() -> String {
+            let calendar = Calendar.current
+            let today = Date()
+            
+            let weekday = calendar.component(.weekday, from: today)
+            let daysToMonday = (weekday + 5) % 7
+            
+            guard let monday = calendar.date(byAdding: .day, value: -daysToMonday, to: today),
+                  let sunday = calendar.date(byAdding: .day, value: 6 - daysToMonday, to: today) else {
+                return "날짜를 가져올 수 없습니다"
+            }
+            
+            let koreanWeekdays = ["일", "월", "화", "수", "목", "금", "토"]
+            let mondayWeekday = koreanWeekdays[calendar.component(.weekday, from: monday) - 1]
+            let sundayWeekday = koreanWeekdays[calendar.component(.weekday, from: sunday) - 1]
+            
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy. MM. dd"
+            dateFormatter.locale = Locale(identifier: "ko_KR")
+            dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+            
+            let mondayString = dateFormatter.string(from: monday)
+            let sundayString = dateFormatter.string(from: sunday)
+            
+            return "\(mondayString) (\(mondayWeekday)) ~ \(sundayString) (\(sundayWeekday))"
+        }
     }
-    
+
     enum Action {
         case routeToPreviousScreen
         case toggleDay(String)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Attendance/AttendanceFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Attendance/AttendanceFeature.swift
@@ -6,16 +6,26 @@
 //
 
 import Foundation
-
 import ComposableArchitecture
 
 @Reducer
 struct AttendanceFeature {
     @ObservableState
     struct State: Equatable {
-        var selectedDays: Set<String> = ["월", "화"]
-        let dateRange: String
-        let weekdays = ["월", "화", "수", "목", "금", "토", "일"]
+        var isLoading: Bool = false
+        var errorMessage: String? = nil
+        var spoonDrawData: SpoonDrawResponseWrapper.SpoonDrawData? = nil
+        
+        var dateRange: String
+        var currentWeekDates: [Date] = []
+        var weekdays = ["월", "화", "수", "목", "금", "토", "일"]
+        var weekdayDateMap: [String: Date] = [:]
+        var attendedWeekdays: [String: SpoonDrawResponse] = [:]
+        
+        var selectedDay: String? = nil
+        var showDrawResultPopup: Bool = false
+        var lastDrawnSpoon: SpoonDrawResponse? = nil
+        
         let noticeItems = [
             "출석체크는 매일 자정에 리셋 되어요",
             "1일 1회 무료로 참여 가능해요",
@@ -23,24 +33,32 @@ struct AttendanceFeature {
         ]
         
         static let initialState = State(
-            dateRange: Self.getCurrentWeekDateRange()
+            dateRange: Self.getCurrentWeekDateRange().0,
+            currentWeekDates: Self.getCurrentWeekDateRange().1,
+            weekdayDateMap: Self.getWeekdayDateMap(Self.getCurrentWeekDateRange().1)
         )
         
-        static func getCurrentWeekDateRange() -> String {
+        static func getCurrentWeekDateRange() -> (String, [Date]) {
             let calendar = Calendar.current
             let today = Date()
             
             let weekday = calendar.component(.weekday, from: today)
             let daysToMonday = (weekday + 5) % 7
             
-            guard let monday = calendar.date(byAdding: .day, value: -daysToMonday, to: today),
-                  let sunday = calendar.date(byAdding: .day, value: 6 - daysToMonday, to: today) else {
-                return "날짜를 가져올 수 없습니다"
+            guard let monday = calendar.date(byAdding: .day, value: -daysToMonday, to: today) else {
+                return ("날짜를 가져올 수 없습니다", [])
+            }
+            
+            var weekDates: [Date] = []
+            for i in 0..<7 {
+                if let date = calendar.date(byAdding: .day, value: i, to: monday) {
+                    weekDates.append(date)
+                }
             }
             
             let koreanWeekdays = ["일", "월", "화", "수", "목", "금", "토"]
             let mondayWeekday = koreanWeekdays[calendar.component(.weekday, from: monday) - 1]
-            let sundayWeekday = koreanWeekdays[calendar.component(.weekday, from: sunday) - 1]
+            let sundayWeekday = koreanWeekdays[calendar.component(.weekday, from: weekDates.last ?? monday) - 1]
             
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy. MM. dd"
@@ -48,16 +66,75 @@ struct AttendanceFeature {
             dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
             
             let mondayString = dateFormatter.string(from: monday)
-            let sundayString = dateFormatter.string(from: sunday)
+            let sundayString = dateFormatter.string(from: weekDates.last ?? monday)
             
-            return "\(mondayString) (\(mondayWeekday)) ~ \(sundayString) (\(sundayWeekday))"
+            return ("\(mondayString) (\(mondayWeekday)) ~ \(sundayString) (\(sundayWeekday))", weekDates)
+        }
+        
+        static func getWeekdayDateMap(_ dates: [Date]) -> [String: Date] {
+            let koreanWeekdays = ["일", "월", "화", "수", "목", "금", "토"]
+            let calendar = Calendar.current
+            
+            var weekdayDateMap: [String: Date] = [:]
+            for date in dates {
+                let weekdayIndex = calendar.component(.weekday, from: date) - 1
+                let koreanWeekday = koreanWeekdays[weekdayIndex]
+                weekdayDateMap[koreanWeekday] = date
+            }
+            
+            return weekdayDateMap
+        }
+        
+        static func dateFromString(_ dateString: String) -> Date? {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+            dateFormatter.locale = Locale(identifier: "ko_KR")
+            dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+            
+            return dateFormatter.date(from: dateString)
+        }
+        
+        static func stringFromDate(_ date: Date) -> String {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+            dateFormatter.locale = Locale(identifier: "ko_KR")
+            dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+            
+            return dateFormatter.string(from: date)
+        }
+        
+        mutating func updateAttendedWeekdays() {
+            guard let spoonDrawData = spoonDrawData else {
+                attendedWeekdays = [:]
+                return
+            }
+            
+            var newAttendedWeekdays: [String: SpoonDrawResponse] = [:]
+            
+            for response in spoonDrawData.spoonDrawResponseDTOList {
+                for (day, date) in weekdayDateMap {
+                    let dateString = Self.stringFromDate(date)
+                    if response.localDate == dateString {
+                        newAttendedWeekdays[day] = response
+                    }
+                }
+            }
+            
+            attendedWeekdays = newAttendedWeekdays
         }
     }
 
     enum Action {
         case routeToPreviousScreen
-        case toggleDay(String)
+        case onAppear
+        case fetchSpoonDrawInfo
+        case spoonDrawResponse(TaskResult<SpoonDrawResponseWrapper>)
+        case drawSpoon(weekday: String)
+        case drawSpoonResponse(TaskResult<SpoonDrawResponse>)
+        case dismissDrawResultPopup
     }
+    
+    @Dependency(\.spoonDrawService) var spoonDrawService
     
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -65,12 +142,67 @@ struct AttendanceFeature {
             case .routeToPreviousScreen:
                 return .none
                 
-            case let .toggleDay(day):
-                if state.selectedDays.contains(day) {
-                    state.selectedDays.remove(day)
-                } else {
-                    state.selectedDays.insert(day)
+            case .onAppear:
+                return .send(.fetchSpoonDrawInfo)
+                
+            case .fetchSpoonDrawInfo:
+                state.isLoading = true
+                state.errorMessage = nil
+                
+                return .run { send in
+                    await send(.spoonDrawResponse(
+                        TaskResult { try await spoonDrawService.fetchSpoonDrawInfo() }
+                    ))
                 }
+                
+            case let .spoonDrawResponse(.success(response)):
+                state.isLoading = false
+                if response.success {
+                    state.spoonDrawData = response.data
+                    state.updateAttendedWeekdays()
+                } else if let errorMessage = response.error?.message {
+                    state.errorMessage = errorMessage
+                }
+                return .none
+                
+            case let .spoonDrawResponse(.failure(error)):
+                state.isLoading = false
+                state.errorMessage = error.localizedDescription
+                return .none
+                
+            case let .drawSpoon(weekday):
+                guard !state.isLoading,
+                      !state.attendedWeekdays.keys.contains(weekday) else {
+                    return .none
+                }
+                
+                state.isLoading = true
+                state.selectedDay = weekday
+                
+                return .run { send in
+                    await send(.drawSpoonResponse(
+                        TaskResult { try await spoonDrawService.drawSpoon() }
+                    ))
+                }
+                
+            case let .drawSpoonResponse(.success(response)):
+                state.isLoading = false
+                state.lastDrawnSpoon = response
+                state.showDrawResultPopup = true
+                
+                // 새로운 데이터 가져오기
+                return .send(.fetchSpoonDrawInfo)
+                
+            case let .drawSpoonResponse(.failure(error)):
+                state.isLoading = false
+                state.errorMessage = "스푼 뽑기 실패: \(error.localizedDescription)"
+                state.selectedDay = nil
+                return .none
+                
+            case .dismissDrawResultPopup:
+                state.showDrawResultPopup = false
+                state.lastDrawnSpoon = nil
+                state.selectedDay = nil
                 return .none
             }
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Attendance/AttendanceView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Attendance/AttendanceView.swift
@@ -27,6 +27,9 @@ struct AttendanceView: View {
             AttendanceInfoSheetView()
                 .presentationDetents([.medium])
         }
+        .task {
+            store.send(.onAppear)
+        }
     }
     
     private var backgroundView: some View {
@@ -86,7 +89,7 @@ struct AttendanceView: View {
             
             Text(store.dateRange)
                 .font(.body2m)
-                .foregroundColor(.gray)
+                .foregroundColor(.gray400)
         }
     }
     
@@ -101,9 +104,11 @@ struct AttendanceView: View {
             ForEach(store.weekdays, id: \.self) { day in
                 SpoonAttendanceView(
                     day: day,
-                    isSelected: store.selectedDays.contains(day),
+                    isSelected: store.attendedWeekdays.keys.contains(day),
                     action: {
-                        store.send(.toggleDay(day))
+                        if !store.attendedWeekdays.keys.contains(day) {
+                            store.send(.drawSpoon(weekday: day))
+                        }
                     }
                 )
             }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Attendance/SpoonAttendanceView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/Attendance/SpoonAttendanceView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct SpoonAttendanceView: View {
     let day: String
     let isSelected: Bool
-    private let action: () -> Void
+    let action: () -> Void
+    
     @State private var showTooltip: Bool = false
     
     init(day: String, isSelected: Bool, action: @escaping () -> Void) {
@@ -21,33 +22,48 @@ struct SpoonAttendanceView: View {
     
     var body: some View {
         ZStack(alignment: .top) {
-            Button(action: {
-                withAnimation(.spring()) {
-                    showTooltip.toggle()
-                }
-            }) {
+            Button(action: action) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 24)
-                        .fill(Color.gray100)
+                        .fill(isSelected ? Color.main500 : Color.gray100)
                         .overlay(
                             RoundedRectangle(cornerRadius: 24)
-                                .strokeBorder(Color.gray200, lineWidth: 8)
+                                .strokeBorder(isSelected ? Color.main100 : Color.gray200, lineWidth: 8)
                         )
                         .frame(width: 105.adjusted, height: 105.adjustedH)
                     
-                    Image("unselectedAttendance")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 80.adjusted, height: 80.adjustedH)
+                    if isSelected {
+                        // 출석 완료된 경우
+                        Image("selectedAttendance")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 80.adjusted, height: 80.adjustedH)
+                    } else {
+                        // 출석하지 않은 경우
+                        Image("unselectedAttendance")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 80.adjusted, height: 80.adjustedH)
+                    }
                     
                     Text(day)
                         .font(.title3b)
-                        .foregroundColor(.gray400)
+                        .foregroundColor(isSelected ? .main400 : .gray400)
                         .frame(width: 90.adjusted, height: 90.adjustedH, alignment: .topLeading)
                         .padding(.top, 12)
                         .padding(.leading, 16)
                 }
                 .frame(width: 105.adjusted, height: 105.adjustedH)
+            }
+            .disabled(isSelected)
+            .onTapGesture {
+                if isSelected {
+                    withAnimation(.spring()) {
+                        showTooltip.toggle()
+                    }
+                } else {
+                    action()
+                }
             }
             
             if showTooltip {

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/MyPageView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/MyPage/MyPageView.swift
@@ -60,7 +60,7 @@ struct MyPageView: View {
                 AttendanceView(store: store)
                     .navigationBarBackButtonHidden()
                     .toolbar(.hidden, for: .tabBar)
-                
+                    
                 // 설정 관련 화면들 추가
             case let .accountManagement(store):
                 AccountManagementView(store: store)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Search/SearchFeature/SearchFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Search/SearchFeature/SearchFeature.swift
@@ -50,6 +50,7 @@ struct SearchFeature {
         case searchCompletedSuccess([SearchResult])
         case searchCompletedFailure(String)
         case routeToPreviousScreen
+        case goBack
     }
     
     var body: some ReducerOf<Self> {
@@ -112,7 +113,7 @@ struct SearchFeature {
                 
             case let .selectLocation(result):
                 state.isSearching = false
-                   return .none
+                return .none
                 
             case let .selectRecentSearch(searchText):
                 state.searchText = searchText
@@ -154,6 +155,12 @@ struct SearchFeature {
             case let .setFirstAppear(isFirst):
                 state.isFirstAppear = isFirst
                 return .none
+                
+            case .goBack:
+                state.searchText = ""
+                state.searchResults = []
+                state.errorMessage = nil
+                return .send(.routeToPreviousScreen)
                 
             }
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Search/Views/SearchView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Search/Views/SearchView.swift
@@ -23,8 +23,7 @@ struct SearchView: View {
                     style: .search(showBackButton: true),
                     searchText: $store.searchText.sending(\.updateSearchText),
                     onBackTapped: {
-                        store.send(.clearSearch)
-                        store.send(.routeToPreviousScreen)
+                        store.send(.goBack) 
                     },
                     tappedAction: {
                         store.send(.search)


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #320 

## 📄 작업 내용
- 지도화면에서 뒤로가기시 이전 네비게이션 타입으로 이동하는 문제를 해결
- 스푼 카운트API 연결하여 첫진입시 스푼뽑기 구현
- 출석체크뷰에서 API로 뽑기 확인 뷰 구현
- 기타 불필요 코드 삭제

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/29e526ec-1671-4d4f-9ef6-b3a949205cb3" width ="250"> | <img src = "" width ="250"> |
