### PR TITLE
[Feat/#335] 자동 로그인 구현

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Network/Auth/TokenAuthenticator.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/TokenAuthenticator.swift
@@ -1,0 +1,54 @@
+//
+//  TokenAuthenticator.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 5/30/25.
+//
+
+import Foundation
+
+import Alamofire
+
+final class TokenAuthenticator: Authenticator {
+    private let refreshService: RefreshProtocol
+    
+    init(refreshService: RefreshProtocol) {
+        self.refreshService = refreshService
+    }
+
+    // 1) 요청하기 전 호출되어 헤더에 JWT 토큰 추가
+    func apply(_ credential: TokenCredential, to urlRequest: inout URLRequest) {
+        urlRequest.headers.add(.authorization(bearerToken: credential.accessToken))
+    }
+    
+    // 2) api 요청 후 응답의 상태코드가 401이면 true를 리턴하며 refresh 프로세스 계속 진행
+    func didRequest(_ urlRequest: URLRequest, with response: HTTPURLResponse, failDueToAuthenticationError error: any Error) -> Bool {
+        return response.statusCode == 401
+    }
+    
+    // 3) 헤더의 token과 credential의 token을 비교
+    // 같은 경우: token 만료 -> refresh()
+    // 다른 경우: apply부터 다시 호출하여 최신 token으로 재시도
+    func isRequest(_ urlRequest: URLRequest, authenticatedWith credential: TokenCredential) -> Bool {
+        let token = HTTPHeader.authorization(bearerToken: credential.accessToken).value
+        return urlRequest.headers["Authorization"] == token
+    }
+    
+    //4) refresh api 호출
+    func refresh(
+        _ credential: TokenCredential,
+        for session: Alamofire.Session,
+        completion: @escaping @Sendable (Result<TokenCredential, any Error>) -> Void
+    ) {
+        let refreshToken = credential.refreshToken
+        
+        Task {
+            do {
+                let tokenSet = try await refreshService.refresh(token: refreshToken)
+                completion(.success(tokenSet))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/TokenCredential.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/TokenCredential.swift
@@ -1,0 +1,17 @@
+//
+//  TokenCredential.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 5/30/25.
+//
+
+import Foundation
+
+import Alamofire
+
+struct TokenCredential: AuthenticationCredential {
+    let accessToken: String
+    let refreshToken: String
+    // 필수
+    var requiresRefresh: Bool = false
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Base/Providers.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Base/Providers.swift
@@ -5,6 +5,7 @@
 //  Created by 이명진 on 1/20/25.
 //
 
+import Alamofire
 import Moya
 
 import Foundation
@@ -24,13 +25,21 @@ struct Providers {
 extension MoyaProvider {
     convenience init(withAuth: Bool) {
         if withAuth {
-            // TODO: - Interceptor, Logger 구현
+            let accessToken = try? KeychainManager.read(key: .accessToken).get()
+            let refreshToken = try? KeychainManager.read(key: .refreshToken).get()
+            
+            let credential = TokenCredential(
+                accessToken: accessToken ?? "",
+                refreshToken: refreshToken ?? ""
+            )
+            let authenticator = TokenAuthenticator(refreshService: DefaultRefreshService.shared)
+            let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+            
             self.init(
-                session: Session(),
+                session: Session(interceptor: interceptor),
                 plugins: [SpoonyLoggingPlugin()]
             )
         } else {
-            // TODO: - Interceptor, Logger 구현
             self.init(plugins: [SpoonyLoggingPlugin()])
         }
     }

--- a/Spoony-iOS/Spoony-iOS/Network/Model/AuthModel/RefreshResponse.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Model/AuthModel/RefreshResponse.swift
@@ -1,0 +1,13 @@
+//
+//  RefreshResponse.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 5/30/25.
+//
+
+import Foundation
+
+struct RefreshResponse: Codable {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/RefreshService.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/RefreshService.swift
@@ -1,0 +1,78 @@
+//
+//  RefreshService.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 5/30/25.
+//
+
+import Foundation
+
+protocol RefreshProtocol {
+    func refresh(token: String) async throws -> TokenCredential
+}
+
+final class DefaultRefreshService: RefreshProtocol {
+    static let shared = DefaultRefreshService()
+    
+    private init() { }
+    
+    let provider = Providers.authProvider
+    
+    private func saveKeychain(access: String, refresh: String) {
+        switch KeychainManager.create(key: .accessToken, value: access) {
+        case .success:
+            print("✅ Access Token saved successfully")
+        case .failure(let error):
+            print("❌ Access Token save failed: \(error)")
+        }
+        
+        switch KeychainManager.create(key: .refreshToken, value: refresh) {
+        case .success:
+            print("✅ Refresh Token saved successfully")
+        case .failure(let error):
+            print("❌ Refresh Token save failed: \(error)")
+        }
+        
+        // 저장 후 바로 읽어보기 테스트
+        switch KeychainManager.read(key: .accessToken) {
+        case .success(let token):
+            print("✅ Access Token read test: \(token?.prefix(30) ?? "nil")")
+        case .failure(let error):
+            print("❌ Access Token read test failed: \(error)")
+        }
+    }
+    
+    func refresh(token: String) async throws -> TokenCredential {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(.refresh(token: token)) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let dto = try response.map(BaseResponse<RefreshResponse>.self)
+                        guard let dto = dto.data else {
+                            continuation.resume(throwing: SNError.noData)
+                            return
+                        }
+                        
+                        self.saveKeychain(access: dto.accessToken, refresh: dto.refreshToken)
+                        let tokenSet: TokenCredential = .init(
+                            accessToken: dto.accessToken,
+                            refreshToken: dto.refreshToken
+                        )
+                        continuation.resume(returning: tokenSet)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+final class MockRefreshService: RefreshProtocol {
+    func refresh(token: String) async throws -> TokenCredential {
+        return TokenCredential(accessToken: "", refreshToken: "")
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Network/TargetType/AuthTargetType.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/TargetType/AuthTargetType.swift
@@ -13,6 +13,7 @@ enum AuthTargetType {
     case signup(SignupRequest, token: String)
     case logout
     case withdraw
+    case refresh(token: String)
 }
 
 extension AuthTargetType: TargetType {
@@ -33,12 +34,14 @@ extension AuthTargetType: TargetType {
             return "/auth/logout"
         case .withdraw:
             return "/auth/withdraw"
+        case .refresh:
+            return "/auth/refresh"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .login, .signup, .logout, .withdraw:
+        case .login, .signup, .logout, .withdraw, .refresh:
             return .post
         }
     }
@@ -52,14 +55,14 @@ extension AuthTargetType: TargetType {
             )
         case .signup(let request, _):
             return .requestCustomJSONEncodable(request, encoder: JSONEncoder())
-        case .logout, .withdraw:
+        case .logout, .withdraw, .refresh:
             return .requestPlain
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .login(_, let token):
+        case .login(_, let token), .refresh(let token):
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(token)"


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #335 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- refresh만을 실행하는 service를 싱글톤으로 구현하였습니다
- test는 not yet... 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`TokenAuthenticator`
- refresh가 호출되기까지 흐름을 주석으로 정리하였습니다
```swift
// 1) 요청하기 전 호출되어 헤더에 JWT 토큰 추가
    func apply(_ credential: TokenCredential, to urlRequest: inout URLRequest) {
        urlRequest.headers.add(.authorization(bearerToken: credential.accessToken))
    }
    
    // 2) api 요청 후 응답의 상태코드가 401이면 true를 리턴하며 refresh 프로세스 계속 진행
    func didRequest(_ urlRequest: URLRequest, with response: HTTPURLResponse, failDueToAuthenticationError error: any Error) -> Bool {
        return response.statusCode == 401
    }
    
    // 3) 헤더의 token과 credential의 token을 비교
    // 같은 경우: token 만료 -> refresh()
    // 다른 경우: apply부터 다시 호출하여 최신 token으로 재시도
    func isRequest(_ urlRequest: URLRequest, authenticatedWith credential: TokenCredential) -> Bool {
        let token = HTTPHeader.authorization(bearerToken: credential.accessToken).value
        return urlRequest.headers["Authorization"] == token
    }
    
    //4) refresh api 호출
    func refresh(
        _ credential: TokenCredential,
        for session: Alamofire.Session,
        completion: @escaping @Sendable (Result<TokenCredential, any Error>) -> Void
    ) {
        let refreshToken = credential.refreshToken
        
        Task {
            do {
                let tokenSet = try await refreshService.refresh(token: refreshToken)
                completion(.success(tokenSet))
            } catch {
                completion(.failure(error))
            }
        }
    }
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 아직 test하기 전이라.. 동작할 거라는 확신이 없네요 ㅎㅎ. 
- 뷰 테스트 후에 서버와 날 잡고 테스트 드가겠습니다.