### PR TITLE
[Feat/#335] 자동 로그인 구현

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Network/Auth/KeychainManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/KeychainManager.swift
@@ -10,6 +10,7 @@ import Foundation
 enum KeychainType: String {
     case accessToken
     case refreshToken
+    case socialType
 }
 
 enum KeychainError: Error {

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/KeychainManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/KeychainManager.swift
@@ -78,4 +78,35 @@ struct KeychainManager {
             return .failure(.failedToDelete)
         }
     }
+    
+    static func saveKeychain(access: String, refresh: String, platform: String) {
+        switch KeychainManager.create(key: .accessToken, value: access) {
+        case .success:
+            print("✅ Access Token saved successfully")
+        case .failure(let error):
+            print("❌ Access Token save failed: \(error)")
+        }
+        
+        switch KeychainManager.create(key: .refreshToken, value: refresh) {
+        case .success:
+            print("✅ Refresh Token saved successfully")
+        case .failure(let error):
+            print("❌ Refresh Token save failed: \(error)")
+        }
+        
+        switch KeychainManager.create(key: .socialType, value: platform) {
+        case .success:
+            print("✅ Refresh Token saved successfully")
+        case .failure(let error):
+            print("❌ Refresh Token save failed: \(error)")
+        }
+        
+        // 저장 후 바로 읽어보기 테스트
+        switch KeychainManager.read(key: .accessToken) {
+        case .success(let token):
+            print("✅ Access Token read test: \(token?.prefix(30) ?? "nil")")
+        case .failure(let error):
+            print("❌ Access Token read test failed: \(error)")
+        }
+    }
 }

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/TokenAuthenticator.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/TokenAuthenticator.swift
@@ -47,6 +47,7 @@ final class TokenAuthenticator: Authenticator {
                 let tokenSet = try await refreshService.refresh(token: refreshToken)
                 completion(.success(tokenSet))
             } catch {
+                AuthenticationManager.shared.handleTokenExpired()
                 completion(.failure(error))
             }
         }

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/TokenAuthenticator.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/TokenAuthenticator.swift
@@ -1,0 +1,54 @@
+//
+//  TokenAuthenticator.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 5/30/25.
+//
+
+import Foundation
+
+import Alamofire
+
+final class TokenAuthenticator: Authenticator {
+    private let refreshService: RefreshProtocol
+    
+    init(refreshService: RefreshProtocol) {
+        self.refreshService = refreshService
+    }
+
+    // 1) 요청하기 전 호출되어 헤더에 JWT 토큰 추가
+    func apply(_ credential: TokenCredential, to urlRequest: inout URLRequest) {
+        urlRequest.headers.add(.authorization(bearerToken: credential.accessToken))
+    }
+    
+    // 2) api 요청 후 응답의 상태코드가 401이면 true를 리턴하며 refresh 프로세스 계속 진행
+    func didRequest(_ urlRequest: URLRequest, with response: HTTPURLResponse, failDueToAuthenticationError error: any Error) -> Bool {
+        return response.statusCode == 401
+    }
+    
+    // 3) 헤더의 token과 credential의 token을 비교
+    // 같은 경우: token 만료 -> refresh()
+    // 다른 경우: apply부터 다시 호출하여 최신 token으로 재시도
+    func isRequest(_ urlRequest: URLRequest, authenticatedWith credential: TokenCredential) -> Bool {
+        let token = HTTPHeader.authorization(bearerToken: credential.accessToken).value
+        return urlRequest.headers["Authorization"] == token
+    }
+    
+    //4) refresh api 호출
+    func refresh(
+        _ credential: TokenCredential,
+        for session: Alamofire.Session,
+        completion: @escaping @Sendable (Result<TokenCredential, any Error>) -> Void
+    ) {
+        let refreshToken = credential.refreshToken
+        
+        Task {
+            do {
+                let tokenSet = try await refreshService.refresh(token: refreshToken)
+                completion(.success(tokenSet))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/TokenCredential.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/TokenCredential.swift
@@ -1,0 +1,17 @@
+//
+//  TokenCredential.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 5/30/25.
+//
+
+import Foundation
+
+import Alamofire
+
+struct TokenCredential: AuthenticationCredential {
+    let accessToken: String
+    let refreshToken: String
+    // 필수
+    var requiresRefresh: Bool = false
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Base/Providers.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Base/Providers.swift
@@ -5,6 +5,7 @@
 //  Created by 이명진 on 1/20/25.
 //
 
+import Alamofire
 import Moya
 
 import Foundation
@@ -24,13 +25,21 @@ struct Providers {
 extension MoyaProvider {
     convenience init(withAuth: Bool) {
         if withAuth {
-            // TODO: - Interceptor, Logger 구현
+            let accessToken = try? KeychainManager.read(key: .accessToken).get()
+            let refreshToken = try? KeychainManager.read(key: .refreshToken).get()
+            
+            let credential = TokenCredential(
+                accessToken: accessToken ?? "",
+                refreshToken: refreshToken ?? ""
+            )
+            let authenticator = TokenAuthenticator(refreshService: DefaultRefreshService.shared)
+            let interceptor = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+            
             self.init(
-                session: Session(),
+                session: Session(interceptor: interceptor),
                 plugins: [SpoonyLoggingPlugin()]
             )
         } else {
-            // TODO: - Interceptor, Logger 구현
             self.init(plugins: [SpoonyLoggingPlugin()])
         }
     }

--- a/Spoony-iOS/Spoony-iOS/Network/Model/AuthModel/RefreshResponse.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Model/AuthModel/RefreshResponse.swift
@@ -1,0 +1,13 @@
+//
+//  RefreshResponse.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 5/30/25.
+//
+
+import Foundation
+
+struct RefreshResponse: Codable {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/AuthService.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/AuthService.swift
@@ -44,7 +44,7 @@ final class DefaultAuthService: AuthProtocol {
                         }
                         
                         if let token = data.jwtTokenDto {
-                            self.saveKeychain(
+                            KeychainManager.saveKeychain(
                                 access: token.accessToken,
                                 refresh: token.refreshToken,
                                 platform: platform
@@ -141,37 +141,6 @@ final class DefaultAuthService: AuthProtocol {
                     continuation.resume(throwing: error)
                 }
             }
-        }
-    }
-    
-    private func saveKeychain(access: String, refresh: String, platform: String) {
-        switch KeychainManager.create(key: .accessToken, value: access) {
-        case .success:
-            print("✅ Access Token saved successfully")
-        case .failure(let error):
-            print("❌ Access Token save failed: \(error)")
-        }
-        
-        switch KeychainManager.create(key: .refreshToken, value: refresh) {
-        case .success:
-            print("✅ Refresh Token saved successfully")
-        case .failure(let error):
-            print("❌ Refresh Token save failed: \(error)")
-        }
-        
-        switch KeychainManager.create(key: .socialType, value: platform) {
-        case .success:
-            print("✅ Social Type saved successfully")
-        case .failure(let error):
-            print("❌ Social Type save failed: \(error)")
-        }
-        
-        // 저장 후 바로 읽어보기 테스트
-        switch KeychainManager.read(key: .accessToken) {
-        case .success(let token):
-            print("✅ Access Token read test: \(token?.prefix(30) ?? "nil")")
-        case .failure(let error):
-            print("❌ Access Token read test failed: \(error)")
         }
     }
     

--- a/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/AuthService.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/AuthService.swift
@@ -46,7 +46,8 @@ final class DefaultAuthService: AuthProtocol {
                         if let token = data.jwtTokenDto {
                             self.saveKeychain(
                                 access: token.accessToken,
-                                refresh: token.refreshToken
+                                refresh: token.refreshToken,
+                                platform: platform
                             )
                         }
                         continuation.resume(returning: data.exists)
@@ -143,7 +144,7 @@ final class DefaultAuthService: AuthProtocol {
         }
     }
     
-    private func saveKeychain(access: String, refresh: String) {
+    private func saveKeychain(access: String, refresh: String, platform: String) {
         switch KeychainManager.create(key: .accessToken, value: access) {
         case .success:
             print("✅ Access Token saved successfully")
@@ -156,6 +157,13 @@ final class DefaultAuthService: AuthProtocol {
             print("✅ Refresh Token saved successfully")
         case .failure(let error):
             print("❌ Refresh Token save failed: \(error)")
+        }
+        
+        switch KeychainManager.create(key: .socialType, value: platform) {
+        case .success:
+            print("✅ Social Type saved successfully")
+        case .failure(let error):
+            print("❌ Social Type save failed: \(error)")
         }
         
         // 저장 후 바로 읽어보기 테스트

--- a/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/RefreshService.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/RefreshService.swift
@@ -16,31 +16,7 @@ final class DefaultRefreshService: RefreshProtocol {
     
     private init() { }
     
-    let provider = Providers.authProvider
-    
-    private func saveKeychain(access: String, refresh: String) {
-        switch KeychainManager.create(key: .accessToken, value: access) {
-        case .success:
-            print("✅ Access Token saved successfully")
-        case .failure(let error):
-            print("❌ Access Token save failed: \(error)")
-        }
-        
-        switch KeychainManager.create(key: .refreshToken, value: refresh) {
-        case .success:
-            print("✅ Refresh Token saved successfully")
-        case .failure(let error):
-            print("❌ Refresh Token save failed: \(error)")
-        }
-        
-        // 저장 후 바로 읽어보기 테스트
-        switch KeychainManager.read(key: .accessToken) {
-        case .success(let token):
-            print("✅ Access Token read test: \(token?.prefix(30) ?? "nil")")
-        case .failure(let error):
-            print("❌ Access Token read test failed: \(error)")
-        }
-    }
+    private let provider = Providers.authProvider
     
     func refresh(token: String) async throws -> TokenCredential {
         return try await withCheckedThrowingContinuation { continuation in
@@ -54,7 +30,11 @@ final class DefaultRefreshService: RefreshProtocol {
                             return
                         }
                         
-                        self.saveKeychain(access: dto.accessToken, refresh: dto.refreshToken)
+                        KeychainManager.saveKeychain(
+                            access: dto.accessToken,
+                            refresh: dto.refreshToken,
+                            platform: AuthenticationManager.shared.socialType.rawValue
+                        )
                         let tokenSet: TokenCredential = .init(
                             accessToken: dto.accessToken,
                             refreshToken: dto.refreshToken

--- a/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/RefreshService.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Service/AuthService/RefreshService.swift
@@ -1,0 +1,78 @@
+//
+//  RefreshService.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 5/30/25.
+//
+
+import Foundation
+
+protocol RefreshProtocol {
+    func refresh(token: String) async throws -> TokenCredential
+}
+
+final class DefaultRefreshService: RefreshProtocol {
+    static let shared = DefaultRefreshService()
+    
+    private init() { }
+    
+    let provider = Providers.authProvider
+    
+    private func saveKeychain(access: String, refresh: String) {
+        switch KeychainManager.create(key: .accessToken, value: access) {
+        case .success:
+            print("✅ Access Token saved successfully")
+        case .failure(let error):
+            print("❌ Access Token save failed: \(error)")
+        }
+        
+        switch KeychainManager.create(key: .refreshToken, value: refresh) {
+        case .success:
+            print("✅ Refresh Token saved successfully")
+        case .failure(let error):
+            print("❌ Refresh Token save failed: \(error)")
+        }
+        
+        // 저장 후 바로 읽어보기 테스트
+        switch KeychainManager.read(key: .accessToken) {
+        case .success(let token):
+            print("✅ Access Token read test: \(token?.prefix(30) ?? "nil")")
+        case .failure(let error):
+            print("❌ Access Token read test failed: \(error)")
+        }
+    }
+    
+    func refresh(token: String) async throws -> TokenCredential {
+        return try await withCheckedThrowingContinuation { continuation in
+            provider.request(.refresh(token: token)) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let dto = try response.map(BaseResponse<RefreshResponse>.self)
+                        guard let dto = dto.data else {
+                            continuation.resume(throwing: SNError.noData)
+                            return
+                        }
+                        
+                        self.saveKeychain(access: dto.accessToken, refresh: dto.refreshToken)
+                        let tokenSet: TokenCredential = .init(
+                            accessToken: dto.accessToken,
+                            refreshToken: dto.refreshToken
+                        )
+                        continuation.resume(returning: tokenSet)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+final class MockRefreshService: RefreshProtocol {
+    func refresh(token: String) async throws -> TokenCredential {
+        return TokenCredential(accessToken: "", refreshToken: "")
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Network/TargetType/AuthTargetType.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/TargetType/AuthTargetType.swift
@@ -13,6 +13,7 @@ enum AuthTargetType {
     case signup(SignupRequest, token: String)
     case logout
     case withdraw
+    case refresh(token: String)
 }
 
 extension AuthTargetType: TargetType {
@@ -33,12 +34,14 @@ extension AuthTargetType: TargetType {
             return "/auth/logout"
         case .withdraw:
             return "/auth/withdraw"
+        case .refresh:
+            return "/auth/refresh"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .login, .signup, .logout, .withdraw:
+        case .login, .signup, .logout, .withdraw, .refresh:
             return .post
         }
     }
@@ -52,14 +55,14 @@ extension AuthTargetType: TargetType {
             )
         case .signup(let request, _):
             return .requestCustomJSONEncodable(request, encoder: JSONEncoder())
-        case .logout, .withdraw:
+        case .logout, .withdraw, .refresh:
             return .requestPlain
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .login(_, let token):
+        case .login(_, let token), .refresh(let token):
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(token)"

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/AppCoordinator/AppCoordinatorView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/AppCoordinator/AppCoordinatorView.swift
@@ -12,6 +12,7 @@ import TCACoordinators
 
 struct AppCoordinatorView: View {
     private let store: StoreOf<AppCoordinator>
+    @StateObject private var authManager = AuthenticationManager.shared
     
     init(store: StoreOf<AppCoordinator>) {
         self.store = store
@@ -31,6 +32,11 @@ struct AppCoordinatorView: View {
                 
             case let .tabRootCoordinator(store):
                 TabRootCoordinatorView(store: store)
+            }
+        }
+        .onChange(of: authManager.authenticationState) {
+            if authManager.authenticationState == .unAuthenticated {
+                store.send(.routeToLoginScreen)
             }
         }
     }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Auth/AuthenticationManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Auth/AuthenticationManager.swift
@@ -28,7 +28,25 @@ final class AuthenticationManager {
         self.socialToken = token
     }
     
-    func checkAuthentication() {
-        // 자동로그인 여부 확인
+    func checkAutoLogin() -> (SocialType, String)? {
+        switch KeychainManager.read(key: .socialType) {
+        case .success(let type):
+            guard let type else { return nil }
+            self.socialType = SocialType.from(rawValue: type) ?? .KAKAO
+        case .failure:
+            print("⛔️ 자동 로그인 실패")
+            return nil
+        }
+        
+        switch KeychainManager.read(key: .accessToken) {
+        case .success(let token):
+            guard let token else { return nil }
+            self.socialToken = token
+        case .failure:
+            print("⛔️ 자동 로그인 실패")
+            return nil
+        }
+        
+        return (self.socialType, self.socialToken ?? "")
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Auth/AuthenticationManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Auth/AuthenticationManager.swift
@@ -14,11 +14,12 @@ enum AuthenticationState {
     case unAuthenticated
 }
 
-final class AuthenticationManager {
+final class AuthenticationManager: ObservableObject {
     static let shared = AuthenticationManager()
     
     private init() { }
     
+    // 로그아웃, 회원탈퇴 시에 unAuthenticated로 바꿔주기
     @Published private(set) var authenticationState: AuthenticationState = .unAuthenticated
     private(set) var socialToken: String?
     private(set) var socialType: SocialType = .KAKAO
@@ -28,25 +29,34 @@ final class AuthenticationManager {
         self.socialToken = token
     }
     
-    func checkAutoLogin() -> (SocialType, String)? {
+    func setAuthenticationState() {
+        authenticationState = .authenticated
+    }
+    
+    func checkAutoLogin() -> Bool {
         switch KeychainManager.read(key: .socialType) {
         case .success(let type):
-            guard let type else { return nil }
+            guard let type else { return false }
             self.socialType = SocialType.from(rawValue: type) ?? .KAKAO
         case .failure:
             print("⛔️ 자동 로그인 실패")
-            return nil
+            return false
         }
         
         switch KeychainManager.read(key: .accessToken) {
         case .success(let token):
-            guard let token else { return nil }
+            guard let token else { return false }
             self.socialToken = token
         case .failure:
             print("⛔️ 자동 로그인 실패")
-            return nil
+            return false
         }
         
-        return (self.socialType, self.socialToken ?? "")
+        self.authenticationState = .unAuthenticated
+        return true
+    }
+    
+    func handleTokenExpired() {
+        authenticationState = .unAuthenticated
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Login/LoginFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Login/LoginFeature.swift
@@ -12,6 +12,10 @@ import ComposableArchitecture
 enum SocialType: String {
     case KAKAO
     case APPLE
+    
+    static func from(rawValue: String) -> SocialType? {
+        return SocialType(rawValue: rawValue)
+    }
 }
 
 enum LoginError: Error {
@@ -57,9 +61,9 @@ struct LoginFeature {
             case .tempHomeButtonTapped:
                 return .send(.routToTabCoordinatorScreen)
             case .onAppear:
-                //자동 로그인시
-//                return .send(.routToTabCoordinatorScreen)
-                return .none
+                guard let (type, token) = authenticationManager.checkAutoLogin() else { return .none }
+                
+                return .send(.routToTabCoordinatorScreen)
             case .kakaoLoginButtonTapped:
                 state.isLoading = true
                 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Login/LoginFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Login/LoginFeature.swift
@@ -61,9 +61,11 @@ struct LoginFeature {
             case .tempHomeButtonTapped:
                 return .send(.routToTabCoordinatorScreen)
             case .onAppear:
-                guard let (type, token) = authenticationManager.checkAutoLogin() else { return .none }
-                
-                return .send(.routToTabCoordinatorScreen)
+                if authenticationManager.checkAutoLogin() {
+                    return .send(.routToTabCoordinatorScreen)
+                } else {
+                    return .none
+                }
             case .kakaoLoginButtonTapped:
                 state.isLoading = true
                 
@@ -93,6 +95,7 @@ struct LoginFeature {
                     do {
                         let isExists = try await authService.login(platform: type.rawValue, token: token)
                         if isExists {
+                            authenticationManager.setAuthenticationState()
                             await send(.routToTabCoordinatorScreen)
                         } else {
                             await send(.routToTermsOfServiceScreen)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
@@ -95,6 +95,7 @@ struct AccountManagementFeature {
                     // 토큰 삭제
                     let _ = KeychainManager.delete(key: .accessToken)
                     let _ = KeychainManager.delete(key: .refreshToken)
+                    let _ = KeychainManager.delete(key: .socialType)
                     return .send(.routeToLoginScreen)
                 } else {
                     state.logoutErrorMessage = "로그아웃에 실패했습니다."

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Setting/AccountManagement/AccountManagementFeature.swift
@@ -43,6 +43,7 @@ struct AccountManagementFeature {
         case routeToLoginScreen
     }
     
+    private let authManager = AuthenticationManager.shared
     @Dependency(\.authService) var authService: AuthProtocol
     
     var body: some ReducerOf<Self> {
@@ -96,6 +97,7 @@ struct AccountManagementFeature {
                     let _ = KeychainManager.delete(key: .accessToken)
                     let _ = KeychainManager.delete(key: .refreshToken)
                     let _ = KeychainManager.delete(key: .socialType)
+                    AuthenticationManager.shared.handleTokenExpired()
                     return .send(.routeToLoginScreen)
                 } else {
                     state.logoutErrorMessage = "로그아웃에 실패했습니다."

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Setting/AccountManagement/withdraw/WithdrawFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Setting/AccountManagement/withdraw/WithdrawFeature.swift
@@ -82,6 +82,7 @@ struct WithdrawFeature {
                     // 회원탈퇴 성공 시 모든 데이터 클리어
                     let _ = KeychainManager.delete(key: .accessToken)
                     let _ = KeychainManager.delete(key: .refreshToken)
+                    let _ = KeychainManager.delete(key: .socialType)
                     
                     // UserDefaults 클리어
                     UserDefaults.standard.removeObject(forKey: "userId")

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Setting/AccountManagement/withdraw/WithdrawFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Setting/AccountManagement/withdraw/WithdrawFeature.swift
@@ -96,6 +96,8 @@ struct WithdrawFeature {
                     UserManager.shared.exploreReviewRecentSearches = nil
                     UserManager.shared.lastAppVisitDate = nil
                     
+                    AuthenticationManager.shared.handleTokenExpired()
+                    
                     return .send(.routeToLoginScreen)
                 }
                 return .none

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Onboarding/OnboardingFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Onboarding/OnboardingFeature.swift
@@ -169,6 +169,9 @@ struct OnboardingFeature {
                             introduction: state.introduceText,
                             token: token
                         )
+                        
+                        AuthenticationManager.shared.setAuthenticationState()
+                        
                         await send(.setUserNickname(user))
                     } catch {
                         await send(.error(error))


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #335 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- refresh만을 실행하는 service를 싱글톤으로 구현하였습니다
- test는 not yet... 

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`TokenAuthenticator`
- refresh가 호출되기까지 흐름을 주석으로 정리하였습니다
```swift
// 1) 요청하기 전 호출되어 헤더에 JWT 토큰 추가
    func apply(_ credential: TokenCredential, to urlRequest: inout URLRequest) {
        urlRequest.headers.add(.authorization(bearerToken: credential.accessToken))
    }
    
    // 2) api 요청 후 응답의 상태코드가 401이면 true를 리턴하며 refresh 프로세스 계속 진행
    func didRequest(_ urlRequest: URLRequest, with response: HTTPURLResponse, failDueToAuthenticationError error: any Error) -> Bool {
        return response.statusCode == 401
    }
    
    // 3) 헤더의 token과 credential의 token을 비교
    // 같은 경우: token 만료 -> refresh()
    // 다른 경우: apply부터 다시 호출하여 최신 token으로 재시도
    func isRequest(_ urlRequest: URLRequest, authenticatedWith credential: TokenCredential) -> Bool {
        let token = HTTPHeader.authorization(bearerToken: credential.accessToken).value
        return urlRequest.headers["Authorization"] == token
    }
    
    //4) refresh api 호출
    func refresh(
        _ credential: TokenCredential,
        for session: Alamofire.Session,
        completion: @escaping @Sendable (Result<TokenCredential, any Error>) -> Void
    ) {
        let refreshToken = credential.refreshToken
        
        Task {
            do {
                let tokenSet = try await refreshService.refresh(token: refreshToken)
                completion(.success(tokenSet))
            } catch {
                completion(.failure(error))
            }
        }
    }
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 아직 test하기 전이라.. 동작할 거라는 확신이 없네요 ㅎㅎ. 
- 뷰 테스트 후에 서버와 날 잡고 테스트 드가겠습니다.