### PR TITLE
[Refactor/#373] @macro를 사용한 반복코드 제거

### DIFF
--- a/Spoony-iOS/Spoony-iOS.xcodeproj/project.pbxproj
+++ b/Spoony-iOS/Spoony-iOS.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		787B5B042D32D9C50017A378 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 787B5B032D32D9C50017A378 /* Kingfisher */; };
 		787B5B072D32DA0F0017A378 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 787B5B062D32DA0F0017A378 /* Moya */; };
 		787B5B0A2D32DA500017A378 /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = 787B5B092D32DA500017A378 /* NMapsMap */; };
-		7893AF402DF698B200B62E48 /* NetworkingMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 7893AF3F2DF698B200B62E48 /* NetworkingMacros */; };
+		7893B4822DF6A03900B62E48 /* NetworkingMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 7893B4812DF6A03900B62E48 /* NetworkingMacros */; };
 		78AD4F082D4299110090E9E3 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 78AD4F072D4299110090E9E3 /* Launch Screen.storyboard */; };
 		78E985B42D564A9D00E02ABB /* FlexSheet in Frameworks */ = {isa = PBXBuildFile; productRef = 78E985B32D564A9D00E02ABB /* FlexSheet */; };
 		ADCF6DE12D9C03D1002F15E8 /* TCACoordinators in Frameworks */ = {isa = PBXBuildFile; productRef = ADCF6DE02D9C03D1002F15E8 /* TCACoordinators */; };
@@ -31,22 +31,9 @@
 		78C002082D1D9FC400DA101C /* Spoony-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Spoony-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		7893AF3D2DF6940700B62E48 /* Exceptions for "Spoony-iOS" folder in "Spoony-iOS" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Network/NetworkingMacros,
-			);
-			target = 78C002072D1D9FC400DA101C /* Spoony-iOS */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		78C0020A2D1D9FC400DA101C /* Spoony-iOS */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				7893AF3D2DF6940700B62E48 /* Exceptions for "Spoony-iOS" folder in "Spoony-iOS" target */,
-			);
 			path = "Spoony-iOS";
 			sourceTree = "<group>";
 		};
@@ -65,7 +52,7 @@
 				7156E2E12D74773300F0C5E7 /* ComposableArchitecture in Frameworks */,
 				78E985B42D564A9D00E02ABB /* FlexSheet in Frameworks */,
 				787B5B042D32D9C50017A378 /* Kingfisher in Frameworks */,
-				7893AF402DF698B200B62E48 /* NetworkingMacros in Frameworks */,
+				7893B4822DF6A03900B62E48 /* NetworkingMacros in Frameworks */,
 				71EDD4792D38EC8700D94926 /* Lottie in Frameworks */,
 				CB6B894C2D8149F400DF264B /* KakaoSDK in Frameworks */,
 				ADCF6DE12D9C03D1002F15E8 /* TCACoordinators in Frameworks */,
@@ -76,7 +63,7 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		7893AF3E2DF698B200B62E48 /* Frameworks */ = {
+		7893B4802DF6A03900B62E48 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -90,7 +77,7 @@
 				71F8F73E2D230EF100B822F3 /* .swiftlint.yml */,
 				78C0020A2D1D9FC400DA101C /* Spoony-iOS */,
 				71F8F8B72D27EE0700B822F3 /* Info.plist */,
-				7893AF3E2DF698B200B62E48 /* Frameworks */,
+				7893B4802DF6A03900B62E48 /* Frameworks */,
 				78C002092D1D9FC400DA101C /* Products */,
 			);
 			sourceTree = "<group>";
@@ -136,7 +123,7 @@
 				CB6B89512D8149F400DF264B /* KakaoSDKCertCore */,
 				CB6B89532D8149F400DF264B /* KakaoSDKCommon */,
 				ADCF6DE02D9C03D1002F15E8 /* TCACoordinators */,
-				7893AF3F2DF698B200B62E48 /* NetworkingMacros */,
+				7893B4812DF6A03900B62E48 /* NetworkingMacros */,
 			);
 			productName = SpoonMe;
 			productReference = 78C002082D1D9FC400DA101C /* Spoony-iOS.app */;
@@ -559,7 +546,7 @@
 			package = 787B5B082D32DA500017A378 /* XCRemoteSwiftPackageReference "SPM-NMapsMap" */;
 			productName = NMapsMap;
 		};
-		7893AF3F2DF698B200B62E48 /* NetworkingMacros */ = {
+		7893B4812DF6A03900B62E48 /* NetworkingMacros */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NetworkingMacros;
 		};

--- a/Spoony-iOS/Spoony-iOS.xcodeproj/project.pbxproj
+++ b/Spoony-iOS/Spoony-iOS.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		787B5B042D32D9C50017A378 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 787B5B032D32D9C50017A378 /* Kingfisher */; };
 		787B5B072D32DA0F0017A378 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 787B5B062D32DA0F0017A378 /* Moya */; };
 		787B5B0A2D32DA500017A378 /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = 787B5B092D32DA500017A378 /* NMapsMap */; };
+		7893AF402DF698B200B62E48 /* NetworkingMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 7893AF3F2DF698B200B62E48 /* NetworkingMacros */; };
 		78AD4F082D4299110090E9E3 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 78AD4F072D4299110090E9E3 /* Launch Screen.storyboard */; };
 		78E985B42D564A9D00E02ABB /* FlexSheet in Frameworks */ = {isa = PBXBuildFile; productRef = 78E985B32D564A9D00E02ABB /* FlexSheet */; };
 		ADCF6DE12D9C03D1002F15E8 /* TCACoordinators in Frameworks */ = {isa = PBXBuildFile; productRef = ADCF6DE02D9C03D1002F15E8 /* TCACoordinators */; };
@@ -30,9 +31,22 @@
 		78C002082D1D9FC400DA101C /* Spoony-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Spoony-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		7893AF3D2DF6940700B62E48 /* Exceptions for "Spoony-iOS" folder in "Spoony-iOS" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Network/NetworkingMacros,
+			);
+			target = 78C002072D1D9FC400DA101C /* Spoony-iOS */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		78C0020A2D1D9FC400DA101C /* Spoony-iOS */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				7893AF3D2DF6940700B62E48 /* Exceptions for "Spoony-iOS" folder in "Spoony-iOS" target */,
+			);
 			path = "Spoony-iOS";
 			sourceTree = "<group>";
 		};
@@ -51,6 +65,7 @@
 				7156E2E12D74773300F0C5E7 /* ComposableArchitecture in Frameworks */,
 				78E985B42D564A9D00E02ABB /* FlexSheet in Frameworks */,
 				787B5B042D32D9C50017A378 /* Kingfisher in Frameworks */,
+				7893AF402DF698B200B62E48 /* NetworkingMacros in Frameworks */,
 				71EDD4792D38EC8700D94926 /* Lottie in Frameworks */,
 				CB6B894C2D8149F400DF264B /* KakaoSDK in Frameworks */,
 				ADCF6DE12D9C03D1002F15E8 /* TCACoordinators in Frameworks */,
@@ -61,6 +76,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7893AF3E2DF698B200B62E48 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		78C001FF2D1D9FC300DA101C = {
 			isa = PBXGroup;
 			children = (
@@ -68,6 +90,7 @@
 				71F8F73E2D230EF100B822F3 /* .swiftlint.yml */,
 				78C0020A2D1D9FC400DA101C /* Spoony-iOS */,
 				71F8F8B72D27EE0700B822F3 /* Info.plist */,
+				7893AF3E2DF698B200B62E48 /* Frameworks */,
 				78C002092D1D9FC400DA101C /* Products */,
 			);
 			sourceTree = "<group>";
@@ -113,6 +136,7 @@
 				CB6B89512D8149F400DF264B /* KakaoSDKCertCore */,
 				CB6B89532D8149F400DF264B /* KakaoSDKCommon */,
 				ADCF6DE02D9C03D1002F15E8 /* TCACoordinators */,
+				7893AF3F2DF698B200B62E48 /* NetworkingMacros */,
 			);
 			productName = SpoonMe;
 			productReference = 78C002082D1D9FC400DA101C /* Spoony-iOS.app */;
@@ -534,6 +558,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 787B5B082D32DA500017A378 /* XCRemoteSwiftPackageReference "SPM-NMapsMap" */;
 			productName = NMapsMap;
+		};
+		7893AF3F2DF698B200B62E48 /* NetworkingMacros */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = NetworkingMacros;
 		};
 		78E985B32D564A9D00E02ABB /* FlexSheet */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/.gitignore
+++ b/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/Package.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/Package.swift
@@ -1,0 +1,43 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+    name: "NetworkingMacros",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "NetworkingMacros",
+            targets: ["NetworkingMacros"]
+        ),
+        .executable(
+            name: "NetworkingMacrosClient",
+            targets: ["NetworkingMacrosClient"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        // Macro implementation that performs the source transformation of a macro.
+        .macro(
+            name: "NetworkingMacrosMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
+
+        // Library that exposes a macro as part of its API, which is used in client programs.
+        .target(name: "NetworkingMacros", dependencies: ["NetworkingMacrosMacros"]),
+
+        // A client of the library, which is able to use the macro in its own code.
+        .executableTarget(name: "NetworkingMacrosClient", dependencies: ["NetworkingMacros"]),
+
+    ]
+)

--- a/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/Sources/NetworkingMacros/NetworkingMacros.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/Sources/NetworkingMacros/NetworkingMacros.swift
@@ -1,0 +1,36 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+/// 네트워킹 서비스 클래스에 provider와 performRequest 메서드를 자동으로 추가하는 매크로
+///
+/// 사용법:
+/// ```swift
+/// @NetworkService
+/// final class HomeService {
+///     // provider와 performRequest 메서드가 자동으로 생성됨
+/// }
+/// ```
+@attached(member, names: named(provider))
+@attached(extension, conformances: ServiceType, names: named(performRequest), named(TargetType))
+public macro NetworkService() = #externalMacro(module: "NetworkingMacrosMacros", type: "NetworkServiceMacro")
+
+/// 비동기 네트워크 요청을 위한 표준 구현을 자동 생성하는 매크로
+@attached(body)
+public macro NetworkRequest<T>(
+    target: String,
+    errorHandling: ErrorHandlingStrategy = .standard
+) = #externalMacro(module: "NetworkingMacrosMacros", type: "NetworkRequestMacro")
+
+/// 에러 처리 전략을 정의하는 열거형
+public enum ErrorHandlingStrategy {
+    case standard
+    case customMessage
+    case spoonService
+}
+
+/// 네트워킹 서비스가 구현해야 하는 프로토콜
+public protocol ServiceType {
+    associatedtype TargetType
+    /// 네트워크 요청을 수행하는 메서드
+    func performRequest<T: Codable>(_ target: TargetType, responseType: T.Type) async throws -> T
+}

--- a/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/Sources/NetworkingMacrosClient/main.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/Sources/NetworkingMacrosClient/main.swift
@@ -1,0 +1,27 @@
+import NetworkingMacros
+import Foundation
+
+struct SimpleResponse: Codable {
+    let message: String
+}
+
+enum SimpleTarget {
+    case getTest
+}
+
+// 매크로 사용 테스트
+@NetworkService
+final class TestService {
+    
+    @NetworkRequest<SimpleResponse>(target: ".getTest")
+    func fetchTest() async throws -> SimpleResponse {}
+}
+
+// 단순 출력 테스트
+print("🎉 NetworkingMacros 빌드 성공!")
+print("✅ @NetworkService 매크로가 정상적으로 작동합니다.")
+print("✅ @NetworkRequest 매크로가 정상적으로 작동합니다.")
+
+let testService = TestService()
+print("✨ TestService 인스턴스 생성 완료")
+print("💡 매크로에 의해 코드가 자동 생성되었습니다!")

--- a/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/Sources/NetworkingMacrosMacros/NetworkingMacrosMacro.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/NetworkingMacros/Sources/NetworkingMacrosMacros/NetworkingMacrosMacro.swift
@@ -1,0 +1,210 @@
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+@main
+struct NetworkingMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        NetworkServiceMacro.self,
+        NetworkRequestMacro.self,
+    ]
+}
+
+/// @NetworkService 매크로 구현체
+public struct NetworkServiceMacro: MemberMacro, ExtensionMacro {
+    
+    // MARK: - MemberMacro 구현
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        
+        // 클래스에만 적용 가능하도록 검증
+        guard let classDecl = declaration.as(ClassDeclSyntax.self) else {
+            throw MacroError.onlyApplicableToClass
+        }
+        
+        // 클래스 이름에서 Service 종류 추출 (예: DefaultHomeService -> home)
+        let className = classDecl.name.text
+        let providerName = extractProviderName(from: className)
+        
+        // provider 프로퍼티 생성
+        let providerDecl: DeclSyntax = """
+            private let provider = Providers.\(raw: providerName)Provider
+            """
+        
+        return [providerDecl]
+    }
+    
+    // MARK: - ExtensionMacro 구현
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        
+        // 클래스 이름에서 TargetType 추출
+        guard let classDecl = declaration.as(ClassDeclSyntax.self) else {
+            throw MacroError.onlyApplicableToClass
+        }
+        
+        let className = classDecl.name.text
+        let targetTypeName = extractTargetTypeName(from: className)
+        
+        // ServiceType 프로토콜 준수 extension 생성
+        let extensionDecl = try ExtensionDeclSyntax("extension \(type): ServiceType") {
+            """
+            typealias TargetType = \(raw: targetTypeName)
+            """
+            
+            try FunctionDeclSyntax("func performRequest<T: Codable>(_ target: \(raw: targetTypeName), responseType: T.Type) async throws -> T") {
+                """
+                return try await withCheckedThrowingContinuation { continuation in
+                    provider.request(target) { result in
+                        switch result {
+                        case .success(let response):
+                            do {
+                                let baseResponse = try response.map(BaseResponse<T>.self)
+                                if baseResponse.success, let data = baseResponse.data {
+                                    continuation.resume(returning: data)
+                                } else {
+                                    continuation.resume(throwing: SNError.noData)
+                                }
+                            } catch {
+                                continuation.resume(throwing: SNError.decodeError)
+                            }
+                        case .failure(let error):
+                            continuation.resume(throwing: error)
+                        }
+                    }
+                }
+                """
+            }
+        }
+        
+        return [extensionDecl]
+    }
+    
+    // 클래스 이름에서 provider 이름 추출
+    private static func extractProviderName(from className: String) -> String {
+        // DefaultHomeService -> home
+        // ExploreService -> explor
+        //(Providers.explorProvider에 맞춤)
+        if className.contains("Home") {
+            return "home"
+        } else if className.contains("Explore") {
+            return "explor"
+        } else if className.contains("Register") {
+            return "register"
+        } else if className.contains("Post") {
+            return "post"
+        } else if className.contains("Auth") {
+            return "auth"
+        } else if className.contains("MyPage") {
+            return "myPage"
+        } else if className.contains("Image") {
+            return "image"
+        } else if className.contains("Follow") {
+            return "follow"
+        } else if className.contains("SpoonDraw") {
+            return "spoonDraw"
+        } else {
+            return "home" // 기본값
+        }
+    }
+    
+    // 클래스 이름에서 TargetType 이름 추출
+    private static func extractTargetTypeName(from className: String) -> String {
+        // DefaultHomeService -> HomeTargetType
+        if className.contains("Home") {
+            return "HomeTargetType"
+        } else if className.contains("Explore") {
+            return "ExploreTargetType"
+        } else if className.contains("Register") {
+            return "RegisterTargetType"
+        } else if className.contains("Post") {
+            return "PostTargetType"
+        } else if className.contains("Auth") {
+            return "AuthTargetType"
+        } else if className.contains("MyPage") {
+            return "MyPageTargetType"
+        } else if className.contains("Image") {
+            return "ImageLoadTargetType"
+        } else if className.contains("Follow") {
+            return "FollowTargetType"
+        } else if className.contains("SpoonDraw") {
+            return "SpoonDrawTargetType"
+        } else {
+            return "HomeTargetType" // 기본값
+        }
+    }
+}
+
+/// @NetworkRequest 매크로 구현체
+public struct NetworkRequestMacro: BodyMacro {
+    
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingBodyFor declaration: some DeclSyntaxProtocol & WithOptionalCodeBlockSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [CodeBlockItemSyntax] {
+        
+        // 함수 선언만 허용
+        guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+            throw MacroError.onlyApplicableToFunction
+        }
+        
+        // 매크로 인자에서 target 추출
+        let arguments = node.arguments?.as(LabeledExprListSyntax.self)
+        guard let targetExpr = arguments?.first(where: { $0.label?.text == "target" })?.expression else {
+            throw MacroError.missingRequiredArgument("target")
+        }
+        
+        // 리턴 타입 추출
+        let returnType = extractReturnType(from: funcDecl)
+        
+        // target 문자열 정리 (따옴표와 점 제거)
+        let targetString = targetExpr.trimmed.description
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: ".", with: "")
+        
+        // 간단한 바디 생성
+        let body: [CodeBlockItemSyntax] = [
+            """
+            return try await performRequest(.\(raw: targetString), responseType: \(raw: returnType).self)
+            """
+        ]
+        
+        return body
+    }
+    
+    /// 함수 리턴 타입 추출
+    private static func extractReturnType(from funcDecl: FunctionDeclSyntax) -> String {
+        guard let returnClause = funcDecl.signature.returnClause else {
+            return "Void"
+        }
+        return returnClause.type.trimmed.description
+    }
+}
+
+/// 매크로 에러 타입
+public enum MacroError: Error, CustomStringConvertible {
+    case onlyApplicableToClass
+    case onlyApplicableToFunction
+    case missingRequiredArgument(String)
+    
+    public var description: String {
+        switch self {
+        case .onlyApplicableToClass:
+            return "@NetworkService는 클래스에만 적용할 수 있습니다."
+        case .onlyApplicableToFunction:
+            return "@NetworkRequest는 함수에만 적용할 수 있습니다."
+        case .missingRequiredArgument(let arg):
+            return "필수 인자 '\(arg)'이 누락되었습니다."
+        }
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Network/Service/HomeService/HomeService.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Service/HomeService/HomeService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import NetworkingMacros
 import Moya
 
 protocol HomeServiceType {
@@ -16,95 +17,23 @@ protocol HomeServiceType {
     func drawDailySpoon() async throws -> SpoonDrawResponse
 }
 
+@NetworkService
 final class DefaultHomeService: HomeServiceType {
-    private let provider = Providers.homeProvider
-
-    func fetchPickList() async throws -> ResturantpickListResponse {
-        return try await withCheckedThrowingContinuation { continuation in
-            Providers.homeProvider.request(.getMapList) { result in
-                switch result {
-                case .success(let response):
-                    do {
-                        let responseDto = try response.map(BaseResponse<ResturantpickListResponse>.self)
-                        guard let data = responseDto.data else {
-                            throw NSError(domain: "HomeService", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data available"])
-                        }
-                        continuation.resume(returning: data)
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
+    
+    @NetworkRequest<ResturantpickListResponse>(target: "getMapList")
+    func fetchPickList() async throws -> ResturantpickListResponse {}
     
     func fetchSpoonCount() async throws -> Int {
-        return try await withCheckedThrowingContinuation { continuation in
-            Providers.homeProvider.request(.getSpoonCount) { result in
-                switch result {
-                case let .success(response):
-                    do {
-                        let baseResponse = try response.map(BaseResponse<SpoonCountResponse>.self)
-                        if baseResponse.success, let data = baseResponse.data {
-                            continuation.resume(returning: data.spoonAmount)
-                        } else {
-                            continuation.resume(throwing: APIError.responseError)
-                        }
-                    } catch {
-                        continuation.resume(throwing: APIError.decodingError)
-                    }
-                case .failure:
-                    continuation.resume(throwing: APIError.invalidResponse)
-                }
-            }
-        }
+        let response: SpoonCountResponse = try await performRequest(.getSpoonCount, responseType: SpoonCountResponse.self)
+        return response.spoonAmount
     }
 
     func fetchFocusedPlace(placeId: Int) async throws -> MapFocusResponse {
-        return try await withCheckedThrowingContinuation { continuation in
-            provider.request(.getMapFocus(placeId: placeId)) { result in
-                switch result {
-                case let .success(response):
-                    do {
-                        let baseResponse = try response.map(BaseResponse<MapFocusResponse>.self)
-                        if baseResponse.success, let data = baseResponse.data {
-                            continuation.resume(returning: data)
-                        } else if let error = baseResponse.error {
-                            continuation.resume(throwing: SearchError.serverError(message: "\(error)"))
-                        } else {
-                            continuation.resume(throwing: SearchError.unknownError)
-                        }
-                    } catch {
-                        continuation.resume(throwing: SearchError.decodingError)
-                    }
-                case .failure:
-                    continuation.resume(throwing: SearchError.networkError)
-                }
-            }
-        }
+        return try await performRequest(.getMapFocus(placeId: placeId), responseType: MapFocusResponse.self)
     }
     
     func fetchLocationList(locationId: Int) async throws -> ResturantpickListResponse {
-        return try await withCheckedThrowingContinuation { continuation in
-            provider.request(.getLocationList(locationId: locationId)) { result in
-                switch result {
-                case .success(let response):
-                    do {
-                        let responseDto = try response.map(BaseResponse<ResturantpickListResponse>.self)
-                        guard let data = responseDto.data else {
-                            throw NSError(domain: "HomeService", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data available"])
-                        }
-                        continuation.resume(returning: data)
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+        return try await performRequest(.getLocationList(locationId: locationId), responseType: ResturantpickListResponse.self)
     }
     
     func drawDailySpoon() async throws -> SpoonDrawResponse {


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #373 

## 📄 작업 내용
- @macro를 사용하여 반복코드를 줄였습니다.

<img width="800" alt="스크린샷 2025-06-09 오후 3 41 17" src="https://github.com/user-attachments/assets/5287dc7d-5c78-4966-acee-f61a575390f2" />

저도 처음 사용해보는거긴 한데 공부겸 공유겸 좀 깊게 파봣습니다.
동작 원리가 궁금하다면 처음부터 글을 봐주셔도 좋고 사용법이랑 뭐가 바뀐건지 보려면 선생님들 코드에 적용하는 방법 부터 보셔도 됩니다.


### 매크로란?

매크로는 **Swift 언어를 사용자에 맞춰서 커스텀해주는 역할**을 합니다.

WWDC에서 소개한 예시 중 제일 이해가 잘되는 예시는 **Codable**과 관련된 예시인데

우리가 보통 Codable을 채택해서 쓸 때, 따로 CodingKeys를 지정해 줄 필요가 없다면 아래처럼 간단하게만 작성하면 됩니다.

```rust
struct Example: Codable {
    let id: String
    let fullName: String
}
```

그치만 사실 `fullName`변수가 json데이터에는 `full_name`으로 온다면, CodingKeys를 추가해주어야죠!

```swift
struct Example: Codable {
    let id: String
    let fullName: String

    enum CodingKeys: String, CodingKey {
        case id
        case fullName = "full_name"
    }

    init(from decoder: Decoder) throws { ... }
    func encode(to: encoder: Encoder) throws { ... }
}
```
됫다!

그럼 CodingKeys를 안쓸때는 이것들이 어캐 동작하는걸까요?

![](https://blog.kakaocdn.net/dn/4wJ0y/btsBb7CGIIB/AOk8g6wE7Kk8Z4nbh4PscK/img.png)

Codable을 사용하면, Swift가 자동으로 관련 코드를 작성해줍니다. 그래서 개발자가 딱히 작동방법을 몰라도 잘 쓸 수 있습니다

![](https://blog.kakaocdn.net/dn/dXWw3O/btsA8qXLkEM/d82GozaoOpgzFFBKsTG5vK/img.png)

Swift에는 이미 Codable과 비슷하게 이런 기능들을 많이 제공하고 있고 이거를 개발자가 알아서 커스텀해라! 하고 나온게 **Macro** 입니다.

또 우리가 지금 사용하는 TCA도 사실 매크로로 잔뜩 압축해 놓은 코드랍니다 

<img width="911" alt="스크린샷 2025-06-09 오후 2 51 16" src="https://github.com/user-attachments/assets/dbd6927c-7100-4cea-a897-ce373966f558" />

<img width="935" alt="스크린샷 2025-06-09 오후 2 52 14" src="https://github.com/user-attachments/assets/79f76441-1db9-4e94-880e-7f4c02e14e54" />

(우클릭 > Expand Macro로 확인가능~)

### 매크로 철학

첫번째 철학은 매크로에는 2가지 종류가 있는데

1. freestanding 매크로 - 항상 샵(`#`) 기호로 시작
2. attached 매크로 - 항상 at(`@`) 기호로 시작

이 두가지 매크로의 종류는 어차피 뒤에서 자세하게 알아볼 것이므로 지금 뭐 이름을 기억해두실 필요도 없습니다. 중요한건 매크로에는 **`#` 이나 `@`** 이 무조건 붙기 때문에, 이 **기호들이 붙어있지 않은 코드**라면, **매크로가 아닌겁니다.** 

**두 번째 철학**는 “매크로에 전달 및 반환되는 코드가 **완전하고 오류가 없는지** 확인되어야 한다”는 것.

**세 번째 철학**는 “매크로 확장이 **예측 가능하고 추가적인(addictive) 방식**으로 프로그램에 통합되어야 한다”는 것입니다.

지금은 그렇게 중요한 내용이 아니니 넘어가고 (다음에 미미나 할때 더 깊게 설명해보겟습니다..)

## 매크로가 수행되는 방법

한 예로 Swift 패키지 플렛폼의 `#stringify` 매크로가 호출되면, **Swift Compiler**는 해당 매크로에 대한 구현이 있는 **Compiler plugin**으로 해당 매크로를 달라는 형태로 요청

- Compiler plugin은 보안 sandbox 별도의 프로세스로 실행

![](https://blog.kakaocdn.net/dn/cokJOQ/btssUa2MwvY/OdwSBSE5SOzPkdICf15DL0/img.png)

- Compiler plugin은 매크로 사용을 처리하고 매크로에 의해 생성된 새로운 코드 조각인 "expansion"을 반환

![](https://blog.kakaocdn.net/dn/1wjeU/btssUPD8Ini/5yKfZQuw8Nye6Aqg6sm4PK/img.png)

- Swift compiler에서 expansion을 받으면 Swift compiler가 expansion을 프로그램에 추가하고 코드의 확장을 함께 컴파일

![](https://blog.kakaocdn.net/dn/bvh1n6/btstbbrJtkG/ZHlRUeMDwuVoywDOfjHi80/img.png)

사실 디자인패턴적인 것들이라서 해당 PR에서 중요한 내용은 아니고 그냥 이런게 있다 정도로만 하고 넘어가고

## 그래서 어떻게 돌아가는건가요

## 컴파일러가 매크로를 만났을 때

먼저 Swift 컴파일러가 제 코드에서 `@NetworkService`를 보자마자, 컴파일러가 이것을 보고 ‘오  매크로다! 코드를 생성해야겠다"라고 인식합니다.

이때 컴파일러는 매크로 정의에서

```swift
 #externalMacro(module: "NetworkingMacrosMacros", type: "NetworkServiceMacro") 
```

부분을 보고,

 "`NetworkingMacrosMacros` 모듈의 `NetworkServiceMacro` 구조체에게 이 일을 맡겨야겠다" 라고 생각합니다.

## SwiftSyntax를 통한 코드 분석 flow

컴파일러는 SwiftSyntax을 사용해서( `NetworkingMacrosMacro`의 임포트된 부분) **소스 코드를 AST**(추상 구문 트리)**로 변환합니다.**

**AST : 코드를 나무 구조로 표현한 것**

⇒  `final class DefaultHomeService: HomeServiceType`이라는 코드는 맨 위에 "클래스 선언"이라는 노드가 있고, 그 아래에 "final 키워드", "클래스 이름 DefaultHomeService", "상속받는 프로토콜 HomeServiceType" 등이 각각의 노드로 연결되어 있는 구조입니다.

```mermaid
graph TD
    A["ClassDeclSyntax (클래스 선언)"] --> B["modifiers (수정자들)"]
    A --> C["classKeyword ('class' 키워드)"]
    A --> D["name (클래스 이름)"]
    A --> E["inheritanceClause (상속 절)"]
    A --> F["memberBlock (멤버 블록)"]
    
    B --> B1["DeclModifierSyntax ('final')"]
    B1 --> B1a["name: 'final'"]
    
    D --> D1["TokenSyntax ('DefaultHomeService')"]
    
    E --> E1["TypeInheritanceClauseSyntax"]
    E1 --> E2["inheritedTypes (상속받는 타입들)"]
    E2 --> E3["InheritedTypeSyntax ('HomeServiceType')"]
    E3 --> E4["type (실제 타입)"]
    E4 --> E5["IdentifierTypeSyntax ('HomeServiceType')"]
    
    F --> F1["MemberBlockSyntax (중괄호 블록)"]
    F1 --> F2["members (멤버들)"]
    F2 --> F3["MemberBlockItemSyntax (각 멤버)"]
```

즉, 문자열 상태로는 컴파일러가 의미를 파악하기 어렵기 때문에. ("`DefaultHomeService`"가 클래스 이름인지, 변수 이름인지, 아니면 그냥 주석의 일부인지 알 수 없음) 컴파일러는 이 평면적인 텍스트를 구조화된 정보로 변환해야 합니다.

그래서 AST가  **구조화된 분석**을 위해서 사용되는거고 매크로가 작동하려면 단순히 "DefaultHomeService"라는 문자열을 찾는 것이 아니라, "이것이 클래스의 이름이다"라는 문맥적 정보가 필요한겁니다.

## 매크로 구현체의 작동 방식

이제 `NetworkServiceMacro` 구조체가 실제로 어떻게 작동하는지 보면, `MemberMacro`와 `ExtensionMacro` 두 개의 프로토콜을 구현했고, 각각 다른 역할을 담당합니다.

`MemberMacro`는 클래스 내부에 새로운 멤버를 추가하는 역할을 합니다. 컴파일러가 `expansion` 메서드를 호출할 때, 이 메서드는 클래스의 AST를 받아서 분석합니다.

```swift
let className = classDecl.name.text  // "DefaultHomeService"라는 문자열을 얻음
let providerName = extractProviderName(from: className)  // "home"으로 변환

```

이 과정에서 매크로는 단순히 문자열 패턴 매칭을 수행합니다. "DefaultHomeService"라는 이름에서 "Home"이라는 부분을 찾아내고, 이를 기반으로 적절한 provider 이름을 결정합니다. 

## 코드 생성 메커니즘

매크로가 AST 분석을 마치면, `SwiftSyntaxBuilder`( 마찬가지로 NetworkingMacrosMacros의 내부 임포트 부분) 를 사용해서 새로운 코드를 생성합니다. 매크로는 "변수 선언을 만들어야겠다"라고 결정하면, 그에 해당하는 AST 노드 구조를 정확히 가져다 조립합니다.

근데 이게 그냥 문자열 조합이 아니라 `SwiftSyntax`의 타입이 잘못된 구문 생성을 원천적으로 차단해줘서, 매크로가 만드는 모든 코드는 구문적으로 유효할 수밖에 없습니다. 

**이를통해 잘못된 코드를 사용하더라도 (여기서는 프로바이더나 타겟타입을 잘못 사용하는 등..)  런타임 에러가 아닌 컴파일 타임에 모든 문제를 발견할 수 있게 됩니다.**

## 성능 최적화?

이거는 좀더 공부가 필요하긴 한데 제 생각과 더불어 말하면,,

- **모듈 경계 제거**:
    - 매크로로 생성된 코드는 사용하는 모듈에 직접 삽입되니까, 런타임에 다른 모듈의 함수를 호출하는 오버헤드가 없습니다. 마치 외부 라이브러리 호출 대신 내부 함수 호출이 되는 것과같은,,
- **간접 호출 제거**:
    - 상속이나 프로토콜 기반 설계에서 필요한 가상 메서드 테이블 조회나 런타임 타입 확인이 불필요해집니다. 컴파일 타임에 모든 호출 경로가 결정되므로 직접 호출이 가능띠예

# 그래서 뭐가 바꼇는데

### Before (이랫는데)

```swift

final class DefaultHomeService: HomeServiceType {
    private let provider = Providers.homeProvider

    func performRequest<T: Codable>(_ target: HomeTargetType, responseType: T.Type) async throws -> T {
        return try await withCheckedThrowingContinuation { continuation in
//우리 모두가 아는 그 길고긴 네트워크로직...
        }
    }
}

```

### After (요래됫슴당)

```swift

@NetworkService// 여기서 provider + performRequest 자동 생성
final class DefaultHomeService: HomeServiceType {

    @NetworkRequest<ResturantpickListResponse>(target: "getMapList")
    func fetchPickList() async throws -> ResturantpickListResponse {}//함수 바디 자동 생성
}

```

**결과**: 40줄 → 3줄로 단축!

## 각 매크로들이 하는 일

### `@NetworkService` 매크로

1. **provider 자동 생성**: 클래스 이름 분석해서 적절한 provider 선택
    - `DefaultHomeService` → `Providers.homeProvider`
    - `ExploreService` → `Providers.explorProvider`
2. **performRequest 메서드 자동 생성**: extension으로 네트워킹 로직 추가

### `@NetworkRequest` 매크로

- **함수 바디 자동 생성**: 빈 함수에 `performRequest` 호출 코드 삽입
- `target` 매개변수를 실제 enum case로 변환

매크로 모듈을 뜯어보거나 Macro expend 해서 보시면 바로 이해가 될겁니다

### 매크로 모듈 뜯어보는 방법

<img width="900" alt="스크린샷 2025-06-10 오전 12 48 43" src="https://github.com/user-attachments/assets/3fb52f6b-d77a-4ec3-a7e8-d810abbba45e" />
@ 으로 되어있는 매크로 우클릭을 한 후 Expand Macro 선택하면면 

<img width="900" alt="스크린샷 2025-06-10 오전 12 50 15" src="https://github.com/user-attachments/assets/9945e7cc-e5ee-44ec-9ef5-734219c67e14" />
이런식으로 숨겨진 매크로 코드가 나오게 됩니다

# 선생님들 코드에 적용하는 방법

### 1. RegisterService

```swift
@NetworkService
final class RegisterService: RegisterServiceType {
    @NetworkRequest<SearchPlaceResponse>(target: "searchPlace")
    func searchPlace(query: String) async throws -> SearchPlaceResponse {}
    
    @NetworkRequest<CategoryListResponse>(target: "getRegisterCategories")
    func getRegisterCategories() async throws -> CategoryListResponse {}
    
    // multipart 요청은 매크로 안됨
    func registerPost(request: RegisterPostRequest, imagesData: [Data]) async throws -> Bool {
        // 이미지 업로드 로직이 복잡해서 수동 처리
        return try await withCheckedThrowingContinuation { continuation in
            // 기존 로직 유지
        }
    }
}
```

### 2. ReportService

```swift
@NetworkService  
final class DefaultReportService: ReportProtocol {
    // 단순한 POST 요청들이라 매크로 적용하기 좋음
    // 하지만 반환 타입이 Void라서 매크로 수정할부분이 있긴하네요,,
    
    func reportPost(postId: Int, report: PostReportType, description: String) async throws {
        let request = PostReportRequest(postId: postId, reportType: report.key, reportDetail: description)
        let _: BlankData = try await performRequest(.reportPost(report: request), responseType: BlankData.self)
        // Void 반환을 위해 결과 무시
    }
    
    func reportUser(targetUserId: Int, report: UserReportType, description: String) async throws {
        let request = UserReportRequest(targetUserId: targetUserId, userReportType: report.key, reportDetail: description)
        let _: BlankData = try await performRequest(.reportUser(report: request), responseType: BlankData.self)
    }
}
```

### 3. ExploreService 는 안되겟다ㅠ

```swift
// 3개의 provider 사용
final class DefaultExploreService: ExploreProtocol {
    let provider = Providers.explorProvider         // 메인 provider
    let registerProvider = Providers.registerProvider  // 카테고리용
    let mypageProvider = Providers.myPageProvider      // 유저/지역용
}
```


## 📚 참고자료
- https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/
- https://developer.apple.com/videos/play/wwdc2023/10167/?time=1233
- https://developer.apple.com/videos/play/wwdc2023/10166/
- https://ios-development.tistory.com/1494
- https://sujinnaljin.medium.com/swift-%EB%A7%A4%ED%81%AC%EB%A1%9C-5e232b78dc5b
- https://www.youtube.com/watch?v=2OCPdw2KTic&t=1878s&ab_channel=KWDC

## 👀 기타 더 이야기해볼 점
며칠전부터 혼자 사부작사부작 갈고있던 코드입니다. 흐름상 빠진게 많고 저도 완벽하게 알지 못하는 부분입니다만 되게 임팩트 있는 내용이여서 QA기간 끝나고 미니세션 열어서 제대로 공유해보겟습니다!