### PR TITLE
[Fix/#361] 자잘한 QA 개선

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Edit/EditProfileFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Edit/EditProfileFeature.swift
@@ -137,11 +137,14 @@ struct EditProfileFeature {
                 return .none
                 
             case .didTapRegisterButton:
+                let birthComponents = state.birthDate
+                let birth: String = birthComponents.allSatisfy { $0.isEmpty } ? "" : birthComponents.joined(separator: "-")
+                
                 let reqeust = EditProfileRequest(
                     userName: state.userNickname,
                     regionId: state.selectedSubLocation?.id ?? 1,
                     introduction: state.introduction,
-                    birth: state.birthDate.joined(separator: "-"),
+                    birth: birth,
                     imageLevel: state.imageLevel
                 )
                 
@@ -151,7 +154,7 @@ struct EditProfileFeature {
                     if success {
                         await send(.routeToPreviousScreen)
                     } else {
-                        await send(.presentToast(message: "서버에 연결할 수 없습니다.\n 잠시 후 다시 시도해 주세요."))
+                        await send(.presentToast(message: "서버에 연결할 수 없습니다.\n잠시 후 다시 시도해 주세요."))
                         await send(.routeToPreviousScreen)
                     }
                 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Following/FollowFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Following/FollowFeature.swift
@@ -108,12 +108,17 @@ struct FollowFeature {
                 return .none
                 
             case .followButtonTapped(let userId, let isFollowing):
-                return .run { send in
+                if let index = state.followingList.firstIndex(where: { $0.userId == userId }) {
+                    // 현재 팔로잉 화면에서 언팔 시 isFollowing만 토글
+                    state.followingList[index].isFollowing.toggle()
+                }
+                return .run { _ in
                     do {
                         try await followUseCase.toggleFollow(userId: userId, isFollowing: isFollowing)
-                        await send(.followActionResponse(.success(())))
+                        // ✅ 성공했지만 새로고침은 하지 않음
+//                        await send(.followActionResponse(.success(())))
                     } catch {
-                        await send(.followActionResponse(.failure(error)))
+                        print("❌ 팔로우 실패: \(error.localizedDescription)")
                     }
                 }
                 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Following/FollowResponseModel.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Following/FollowResponseModel.swift
@@ -16,7 +16,7 @@ struct FollowUserDTO: Codable, Equatable {
     let userId: Int
     let username: String
     let regionName: String?
-    let isFollowing: Bool
+    var isFollowing: Bool
     let profileImageUrl: String
     let isMine: Bool
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostFeature.swift
@@ -231,6 +231,9 @@ struct PostFeature {
                 return .none
                 
             case .showUseSpoonPopup:
+                if state.spoonCount <= 0 {
+                    return .send(.showToast("남은 스푼이 없어요 ㅠ.ㅠ"))
+                }
                 state.isUseSpoonPopupVisible = true
                 return .none
                 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostFeature.swift
@@ -161,7 +161,7 @@ struct PostFeature {
                 if isScrap {
                     state.zzimCount += 1
                     state.isZzim.toggle()
-                    return .send(.showToast("내 지도에 추가되었어요."))
+                    return .send(.showToast("내 지도에 저장되었어요."))
                 } else {
                     state.zzimCount -= 1
                     state.isZzim.toggle()

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
@@ -312,13 +312,20 @@ extension PostView {
     }
     
     // 흠 아쉬워요 섹션
+    @ViewBuilder
     private var hmmJustOneThingSection: some View {
-        ZStack(alignment: .center) {
-            baseHmmSection
-            
-            Group {
+        if !store.cons.isEmpty {
+            ZStack(alignment: .center) {
+                baseHmmSection
+                
                 if !(store.isScoop || store.isMine) {
-                    SpoonyButton(style: .primary, size: .minusSpoon, title: "스푼 1개 써서 확인하기", isIcon: true, disabled: .constant(false)) {
+                    SpoonyButton(
+                        style: .primary,
+                        size: .minusSpoon,
+                        title: "스푼 1개 써서 확인하기",
+                        isIcon: true,
+                        disabled: .constant(false)
+                    ) {
                         store.send(.showUseSpoonPopup)
                     }
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -535,7 +542,7 @@ struct PostScrapButton: View {
     
     let store = Store(initialState: PostFeature.State()) {
         PostFeature()
-            .dependency(\.postUseCase, PostUseCaseKey.liveValue)
+            .dependency(\.postUseCase, PostUseCaseKey.testValue)
     }
     
     return PostView(postId: 30, store: store)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
@@ -318,7 +318,7 @@ extension PostView {
             ZStack(alignment: .center) {
                 baseHmmSection
                     .frame(height: (store.isScoop || store.isMine) ? nil : 120.adjustedH)
-
+                
                 if !(store.isScoop || store.isMine) {
                     SpoonyButton(
                         style: .primary,
@@ -354,6 +354,10 @@ extension PostView {
             trailing: 20.adjusted
         ))
         .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(
+            height: (store.isScoop || store.isMine) ? nil : 119.adjustedH,
+            alignment: .top
+        )
         .background {
             Color.gray0
                 .cornerRadius(20, corners: [.topLeft, .topRight])

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
@@ -317,7 +317,6 @@ extension PostView {
         if !store.cons.isEmpty {
             ZStack(alignment: .center) {
                 baseHmmSection
-                    .frame(height: (store.isScoop || store.isMine) ? nil : 120.adjustedH)
                 
                 if !(store.isScoop || store.isMine) {
                     SpoonyButton(

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
@@ -154,7 +154,7 @@ extension PostView {
                     .foregroundStyle(.black)
                 
                 if !store.regionName.isEmpty {
-                    Text(store.regionName)
+                    Text("서울 \(store.regionName) 스푼")
                         .customFont(.caption1m)
                         .foregroundStyle(.gray400)
                 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
@@ -317,7 +317,8 @@ extension PostView {
         if !store.cons.isEmpty {
             ZStack(alignment: .center) {
                 baseHmmSection
-                
+                    .frame(height: (store.isScoop || store.isMine) ? nil : 120.adjustedH)
+
                 if !(store.isScoop || store.isMine) {
                     SpoonyButton(
                         style: .primary,
@@ -329,6 +330,7 @@ extension PostView {
                         store.send(.showUseSpoonPopup)
                     }
                     .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.bottom, -16.adjustedH)
                 }
             }
         }
@@ -343,6 +345,7 @@ extension PostView {
             Text(store.cons)
                 .font(.body2m)
                 .foregroundStyle(.gray900)
+                .blur(radius: (store.isScoop || store.isMine) ? 0 : 12)
         }
         .padding(EdgeInsets(
             top: 20.adjustedH,
@@ -357,7 +360,6 @@ extension PostView {
         }
         .padding(.horizontal, 20.adjusted)
         .padding(.bottom, 12.adjustedH)
-        .blur(radius: (store.isScoop || store.isMine) ? 0 : 12)
     }
     
     private var menuInfo: some View {

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
@@ -197,13 +197,16 @@ extension PostView {
                     }
             }
         }
+        .zIndex(1)
         .padding(.vertical, 8.adjustedH)
         .padding(.horizontal, 20.adjustedH)
         .padding(.bottom, 24.adjustedH)
         .onTapGesture {
             if store.isMine {
+                print("내 페이지로")
                 store.send(.routeToMyProfileScreen)
             } else {
+                print("남의 페이지로")
                 store.send(.routeToUserProfileScreen(store.userId))
             }
         }
@@ -547,8 +550,8 @@ struct PostScrapButton: View {
     
     let store = Store(initialState: PostFeature.State()) {
         PostFeature()
-            .dependency(\.postUseCase, PostUseCaseKey.testValue)
+            .dependency(\.postUseCase, PostUseCaseKey.liveValue)
     }
     
-    return PostView(postId: 30, store: store)
+    return PostView(postId: 51, store: store)
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #361

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
### QA 쳐내기

- [x] PostView에서 스푼 0개일때 떠먹기 다른거 모달 떠야함 -> 걍 토스트 띄우는걸로 일단 수정
- [x] PostView에서 떠먹기 모달이 구 버전임 <주리>
- [x] PostView에서  장소 정보 "서울 강남구 스푼"으로 바꿔줘
- [x] PostView에서 cons 없을 때 맨 마지막 Cell 없애기, 제목은 블러처리 안되게 변경
- [x] PostView에서 상단 터치 zIndex 최상단으로 보내서 해결
- [ ] 전체) 토스트 메세지 폰트 문제? (이게 뭐지) 질문 남김
- [x] 타 유저 페이지랑 마이페이지랑 구분이 안되어있음 <주리>
  - [ ] 마이 -> 리뷰 Label 옆 리뷰 갯수가 안 맞음 (서버에서 잘 못내려주는거 같은데..??)
- [x] 프로필 수정 뷰에서 날짜 배열 비어있으면 빈 String 값을 보내야함
- [x] 팔로잉/팔로우 뷰에서 버튼 뒤로가기버튼 안됌 (스와이프는 됌) <주리>
- [x] 팔로잉 뷰에서 언팔 할때 뷰 업데이트가 되면 안됌
