### PR TITLE
[Feat/#391] 스푼 박살내기 구현 90% 완료

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -196,6 +196,9 @@ struct CustomNavigationBar: View {
             
             LogoChip(type: .small, count: spoonCount)
                 .padding(.trailing, 20)
+                .onTapGesture {
+                    spoonTapped?()
+                }
         }
     }
     

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/TabRootCoordinator/TabRootCoordinator.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Coordinator/TabRootCoordinator/TabRootCoordinator.swift
@@ -250,6 +250,11 @@ struct TabRootCoordinator {
                 
 //            case .router(.routeAction(id: _, action: .registerAndEdit(.presentPopup)))
                 
+                // 출석체크
+            case .router(.routeAction(id: _, action: .post(.routeToAttendanceView))):
+                state.routes.push(.attendance(.initialState))
+                return .none
+                
             case .router(.routeAction(id: _, action: .report(.routeToRoot))):
                 return .send(.routeToRoot)
                 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Post/Presentation/PostView.swift
@@ -36,6 +36,10 @@ struct PostView: View {
                     spoonCount: store.spoonCount,
                     onBackTapped: {
                         store.send(.routeToPreviousScreen)
+                    },
+                    spoonTapped: {
+                        store.send(.spoonTapped)
+                        print("스푼 이밴트")
                     }
                 )
                 ScrollView(.vertical) {
@@ -71,7 +75,6 @@ struct PostView: View {
                 bottomView
                     .frame(height: 80.adjustedH)
             }
-
             .toolbar(.hidden, for: .tabBar)
             
             if store.isLoading {
@@ -116,6 +119,27 @@ struct PostView: View {
                 }
             }
         )
+        .overlay {
+            if store.showDailySpoonPopup {
+                SpoonDrawPopupView(
+                    isPresented: Binding(
+                        get: {
+                            return store.showDailySpoonPopup
+                        },
+                        set: { newValue in
+                            store.send(.setShowDailySpoonPopup(newValue))
+                        }
+                    ),
+                    onDrawSpoon: {
+                        // 드로우 버튼
+                        store.send(.drawDailySpoon)
+                    },
+                    isDrawing: store.isDrawingSpoon,
+                    drawnSpoon: store.drawnSpoon,
+                    errorMessage: store.spoonDrawError
+                )
+            }
+        }
         .navigationBarBackButtonHidden()
     }
 }
@@ -179,7 +203,7 @@ extension PostView {
                     .onChange(of: store.isFollowing) { oldValue, newValue in
                         // 값이 실제로 변경되었는지 한 번 더 확인 코드 입니다. (중복 호출 방지용)
                         guard oldValue != newValue else { return }
-
+                        
                         let generator = UIImpactFeedbackGenerator(style: .light)
                         generator.impactOccurred()
                     }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #391 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 스푼 뽑기 기능을 추가 하였습니다.

|    스푼 처음 뽑았을 경우    |   스푼을 이미 뽑았을 경우(출첵 뷰로만 이동해야함 모달 뜨면 안돼 ⛔️ )   |  
| :-------------: | :----------: |
| ![ScreenRecording_06-16-2025 22-54-28_1](https://github.com/user-attachments/assets/73a9831d-91f0-4e57-842e-133531a527f9)  |   ![ScreenRecording_06-16-2025 22-45-45_1](https://github.com/user-attachments/assets/35c8fa1a-1545-48ea-9ced-d1836fb5899d) |


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`PostFeature.swift`

#### 지훈쌤 말대로 `UserManager.shared.isFirstVisitOfDay()` 에 따라서 로직을 구현 했습니다.

##### 1. UserManager.shared.isFirstVisitOfDay() 이 true 일때 ( 이미 스푼 뽑았을 경우 )

-> `routeToAttendanceView` 로 이동

##### 2. UserManager.shared.isFirstVisitOfDay() 이 false 일때 ( 스푼 안 뽑았을 경우 ) 

-> `SpoonDrawPopupView`


```swift
case .spoonTapped:
    print("🔍 isFirstVisitOfDay: \(UserManager.shared.isFirstVisitOfDay())")
    if !UserManager.shared.isFirstVisitOfDay() { // 지훈쌤이 스푼 뽑았으면 true 라고 했음
        print("🔍 스푼 뽑기를 안헀으면 팝업 표시")
        return .send(.setShowDailySpoonPopup(true))
    } else {
        print("🔍 스푼 뽑기을 했으면 AttendanceView로 이동")
        return .send(.routeToAttendanceView)
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

1. 코디네이터 썼는데 뷰가 네비게이션 바가 있어야 할 것처럼 올라가 있음
2. 정확히 알아야하는건 오늘 스푼을 뽑았는지 안뽑았는지 인데 .. 그 트리거가 없는 거 같아서 수정 부탁드립니다!!!
3. 그리고 화면 전환할떄 모달이 뜨면 안됌 (스푼 뽑았는지 여부에 따라 분기가 필요함..) 