### PR TITLE
fix: #441 필터링 많이 저장 순 안되는 버그 해결

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Mixpanel/Events/ExploreEvents.swift
+++ b/Spoony-iOS/Spoony-iOS/Mixpanel/Events/ExploreEvents.swift
@@ -17,7 +17,7 @@ struct ExploreEvents {
         var sortType: SortType
         
         var dictionary: [String: MixpanelType] {
-            ["sort_type": sortType.rawValue]
+            ["sort_type": sortType.mixpanelKey]
         }
     }
     

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Explore/Filtering/SortBottomSheet.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Explore/Filtering/SortBottomSheet.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 enum SortType: String, CaseIterable {
-    case createdAt = "latest"
-    case zzimCount = "most_saved"
+    case createdAt
+    case zzimCount
     
     var title: String {
         switch self {
@@ -17,6 +17,15 @@ enum SortType: String, CaseIterable {
             "최신순"
         case .zzimCount:
             "저장 많은 순"
+        }
+    }
+    
+    var mixpanelKey: String {
+        switch self {
+        case .createdAt:
+            "latest"
+        case .zzimCount:
+            "most_saved"
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #441 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- mixpanel key로 사용하고 있던 값을 분리해줬습니다
