### PR TITLE
Fix/#429 자동 로그인 수정

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Network/Auth/KeychainManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/KeychainManager.swift
@@ -53,15 +53,10 @@ struct KeychainManager {
         var result: AnyObject?
         let status = SecItemCopyMatching(query, &result)
         
-        if status == errSecSuccess {
-            guard let data = result as? Data,
-                  let value = String(data: data, encoding: String.Encoding.utf8)
-            else { return "" }
-            
-            return value
-        } else {
-            return ""
-        }
+        guard let data = result as? Data,
+              let value = String(data: data, encoding: String.Encoding.utf8) else { return nil }
+        
+        return value
     }
     
     static func delete(key: KeychainType) -> Result<Void, KeychainError> {

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/KeychainManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/KeychainManager.swift
@@ -43,7 +43,7 @@ struct KeychainManager {
         }
     }
     
-    static func read(key: KeychainType) -> Result<String?, KeychainError> {
+    static func read(key: KeychainType) -> String? {
         let query: NSDictionary = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key.rawValue,
@@ -56,11 +56,11 @@ struct KeychainManager {
         if status == errSecSuccess {
             guard let data = result as? Data,
                   let value = String(data: data, encoding: String.Encoding.utf8)
-            else { return .failure(.invalidData) }
+            else { return "" }
             
-            return .success(value)
+            return value
         } else {
-            return .failure(.failedToRead)
+            return ""
         }
     }
     
@@ -102,11 +102,6 @@ struct KeychainManager {
         }
         
         // 저장 후 바로 읽어보기 테스트
-        switch KeychainManager.read(key: .accessToken) {
-        case .success(let token):
-            print("✅ Access Token read test: \(token?.prefix(30) ?? "nil")")
-        case .failure(let error):
-            print("❌ Access Token read test failed: \(error)")
-        }
+        print("✅ Access Token read test: \(KeychainManager.read(key: .accessToken)?.prefix(30) ?? "nil")")
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/TokenAuthenticator.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/TokenAuthenticator.swift
@@ -53,6 +53,10 @@ final class TokenAuthenticator: Authenticator {
         Task {
             do {
                 let tokenSet = try await refreshService.refresh(token: refreshToken)
+                
+                _ = KeychainManager.create(key: .accessToken, value: tokenSet.accessToken)
+                _ = KeychainManager.create(key: .refreshToken, value: tokenSet.refreshToken)
+                
                 completion(.success(tokenSet))
             } catch {
                 await MainActor.run {

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/TokenCredential.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/TokenCredential.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import Alamofire
 
-struct TokenCredential: AuthenticationCredential {
+struct TokenCredential: AuthenticationCredential, Equatable {
     let accessToken: String
     let refreshToken: String
     // 필수

--- a/Spoony-iOS/Spoony-iOS/Network/Auth/TokenManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Auth/TokenManager.swift
@@ -12,20 +12,10 @@ final class TokenManager {
     private init() {}
     
     var currentToken: String? {
-        switch KeychainManager.read(key: .accessToken) {
-        case .success(let token):
-            return token
-        case .failure:
-            return nil
-        }
+        return KeychainManager.read(key: .accessToken)
     }
     
     var currentRefreshToken: String? {
-        switch KeychainManager.read(key: .refreshToken) {
-        case .success(let token):
-            return token
-        case .failure:
-            return nil
-        }
+        return KeychainManager.read(key: .refreshToken)
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Network/Base/HeaderType.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Base/HeaderType.swift
@@ -11,28 +11,20 @@ enum HeaderType {
     case noAuth     // authorization 불필요 시 사용
     case auth       // authorization 필요 시 사용
     case token(String)      // 소셜 로그인 -> 서버 로그인 토큰 전달 시 사용
+    case multipart          // 이미지 업로드 시 사용
     
     var value: [String: String]? {
         switch self {
         case .noAuth:
-            return [
-                "Content-Type": "application/json"
-            ]
-            // 여기 토큰 바꾸기
+            return ["Content-Type": "application/json"]
         case .auth:
-            switch KeychainManager.read(key: .accessToken) {
-            case .success(let token):
-                guard let token else {
-                    print("Access Token Nil Error")
-                    return [:]
-                }
-                
+            if let token = TokenManager.shared.currentToken {
                 return [
                     "Content-Type": "application/json",
                     "Authorization": "Bearer \(token)"
                 ]
-            case .failure(let error):
-                print("Keychain Read Error: \(error)")
+            } else {
+                print("⛔️ Key chain Error")
                 return [:]
             }
         case .token(let token):
@@ -40,6 +32,16 @@ enum HeaderType {
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(token)"
             ]
+        case .multipart:
+            if let token = TokenManager.shared.currentToken {
+                return [
+                    "Content-Type": "multipart/form-data",
+                    "Authorization": "Bearer \(token)"
+                ]
+            } else {
+                print("⛔️ Key chain Error")
+                return [:]
+            }
         }
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Network/TargetType/AuthTargetType.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/TargetType/AuthTargetType.swift
@@ -63,28 +63,11 @@ extension AuthTargetType: TargetType {
     var headers: [String: String]? {
         switch self {
         case .login(_, let token), .refresh(let token):
-            return [
-                "Content-Type": "application/json",
-                "Authorization": "Bearer \(token)"
-            ]
+            return HeaderType.token(token).value
         case .signup(_, let token):
-            return [
-                "Content-Type": "application/json",
-                "Authorization": "Bearer \(token)"
-            ]
+            return HeaderType.token(token).value
         case .logout, .withdraw:
-            var headers = ["Content-Type": "application/json"]
-            
-            switch KeychainManager.read(key: .accessToken) {
-            case .success(let token):
-                if let token = token {
-                    headers["Authorization"] = "Bearer \(token)"
-                }
-            case .failure(let error):
-                print("Failed to read access token: \(error)")
-            }
-            
-            return headers
+            return HeaderType.auth.value
         }
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Network/TargetType/RegisterTargetType.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/TargetType/RegisterTargetType.swift
@@ -83,22 +83,7 @@ extension RegisterTargetType: TargetType {
 //            return Config.defaultHeader
             return HeaderType.auth.value
         case .registerPost, .editPost:
-            switch KeychainManager.read(key: .accessToken) {
-            case .success(let token):
-                guard let token else {
-                    print("Access Token Nil Error")
-                    return [:]
-                }
-                
-                return [
-                    "Content-Type": "multipart/form-data",
-                    "Authorization": "Bearer \(token)"
-                ]
-            case .failure(let error):
-                print("Keychain Read Error: \(error)")
-                return [:]
-            }
-            
+            return HeaderType.multipart.value
         }
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Auth/AuthenticationManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Auth/AuthenticationManager.swift
@@ -23,21 +23,15 @@ final class AuthenticationManager: ObservableObject {
     }
     
     func checkAutoLogin() -> Bool {
-        switch KeychainManager.read(key: .socialType) {
-        case .success(let type):
-            guard let type else { return false }
-            self.socialType = SocialType.from(rawValue: type) ?? .KAKAO
-        case .failure:
-            print("⛔️ 자동 로그인 실패")
-            return false
-        }
         
-        switch KeychainManager.read(key: .accessToken) {
-        case .success(let token):
-            guard let token else { return false }
-            self.socialToken = token
-        case .failure:
-            print("⛔️ 자동 로그인 실패")
+        let social = KeychainManager.read(key: .socialType)
+        self.socialType = SocialType.from(rawValue: social ?? "") ?? .KAKAO
+
+        let token = KeychainManager.read(key: .accessToken)
+        self.socialToken = token
+        
+        if let token, let social {
+            print("⛔️자동 로그인 실패")
             return false
         }
         

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Auth/AuthenticationManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/Auth/AuthenticationManager.swift
@@ -30,7 +30,7 @@ final class AuthenticationManager: ObservableObject {
         let token = KeychainManager.read(key: .accessToken)
         self.socialToken = token
         
-        if let token, let social {
+        if token == nil {
             print("⛔️자동 로그인 실패")
             return false
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Profile/ProfileFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Profile/ProfileFeature.swift
@@ -78,17 +78,10 @@ struct ProfileFeature {
             case .onAppear:
                 state.isLoading = true
                 state.errorMessage = nil
-                
-                switch KeychainManager.read(key: .accessToken) {
-                case .success(let token):
-                    if token == nil {
-                        state.isLoading = false
-                        state.errorMessage = "로그인이 필요합니다."
-                        return .none
-                    }
-                case .failure(let error):
+
+                if let token = KeychainManager.read(key: .accessToken) { } else {
                     state.isLoading = false
-                    state.errorMessage = "인증 정보를 불러올 수 없습니다: \(error.localizedDescription)"
+                    state.errorMessage = "로그인이 필요합니다."
                     return .none
                 }
                 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Profile/ProfileFeature.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Scene/MyPage/Profile/ProfileFeature.swift
@@ -79,7 +79,7 @@ struct ProfileFeature {
                 state.isLoading = true
                 state.errorMessage = nil
 
-                if let token = KeychainManager.read(key: .accessToken) { } else {
+                if KeychainManager.read(key: .accessToken) == nil {
                     state.isLoading = false
                     state.errorMessage = "로그인이 필요합니다."
                     return .none


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #429


## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- KeychainManager read 수정
- headerType 사용하도록 target type 수정
- refresh 후 토큰 저장 로직 추가 -> 이거때문에 refresh가 안되고 있었슨...
- refresh를 한 번만 하도록 보장하는 actor 구현

## 💻 주요 코드 설명

### 왜 refresh가 안될까?
refresh 호출 후에 200 status code가 받아와지는 걸로 봐서 refresh 자체는 잘 호출이 되고 있었습니다만 
제가 refresh해서 받아온 토큰 셋을 저장하지 않고 있더라구요 ㅎㅋ  그래서 저장해줬습니다...

그랬더니

### 423 에러 등장...
요 친구는 401이 떴을 때 refresh를 통해 새로운 토큰 셋을 받아오고 난 후에 **싱글톤**으로 관리하고 있어서 
바로 변경된 토큰으로 다시 refresh를 호출해서 발생하는 에러였어요....
동시에 API 3~4개를 호출해야하는 뷰가 많아서 계속 이런 에러가 발생했습니다..

### 그래서 refresh를 딱 한 번만 하도록 보장하고 싶었어요!!!

항상 같은 객체를 거쳐서 refresh를 하고, flag를 통해 관리하면 이것이 보장이 될 거라고 생각하여
처음엔 **class**를 이용해서 구현했습니다...
-> 그랬더니 data race 발생 .... 동시에 접근해서 실행하면 이게 제어가 안됨

그래서 **actor**를 도입해보았어요
actor는 한 번에 하나의 접근만 일어나서 동시에 여러 스레드에서 해당 변수에 접근해도 data race 발생하지 않기 때문에
refresh가 잘 되는 것을 확인하였습니다..

- 제가 액터를 사용해보았는데요... 적절하게 사용했는지 너무너무 궁금해요
```swift
fileprivate actor RefreshActor {
    private var isRefreshing = false
    // actor는 한 번에 하나의 접근만 일어나서 동시에 여러 스레드에서 해당 변수에 접근해도 data race 발생 X
    private var currentTask: Task<TokenCredential, Error>?
    
    func performRefresh(refreshToken: String, service: RefreshProtocol) async throws -> TokenCredential {
        return try await refresh(refreshToken: refreshToken, service: service)
    }
    
    private func refresh(refreshToken: String, service: RefreshProtocol) async throws -> TokenCredential {
        let currentRefreshToken = TokenManager.shared.currentRefreshToken ?? ""
        
        // 이미 refresh 됨
        if refreshToken != currentRefreshToken {
            return TokenCredential(
                accessToken: TokenManager.shared.currentToken ?? "",
                refreshToken: currentRefreshToken
            )
        }
        
        // 이미 진행 중인 refresh task가 있으면 해당 task의 결과를 return
        // refresh가 한 번만 호출되도록 보장
        if let currentTask {
            return try await currentTask.value
        }
        
        // refresh하는 Task를 생성
        let newTask = Task { () throws -> TokenCredential in
            defer { currentTask = nil }
            do {
                let tokenSet = try await service.refresh(token: refreshToken)
                
                _ = KeychainManager.create(key: .accessToken, value: tokenSet.accessToken)
                _ = KeychainManager.create(key: .refreshToken, value: tokenSet.refreshToken)
                return tokenSet
            } catch {
                await MainActor.run {
                    _ = KeychainManager.delete(key: .accessToken)
                    _ = KeychainManager.delete(key: .refreshToken)
                    _ = KeychainManager.delete(key: .socialType)
                    NotificationCenter.default.post(name: .loginNotification, object: nil)
                }
                
                throw error
            }
        }
        currentTask = newTask
        return try await newTask.value
    }
}
```