### PR TITLE
Refactor/#473 NSLock -> actor 마이그레이션

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Network/Base/Providers.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Base/Providers.swift
@@ -48,7 +48,7 @@ extension MoyaProvider {
                             response: response.response
                         )
                     )
-                case .failure(let error):
+                case .failure:
                     continuation.resume(throwing: SNError.networkFail)
                 }
             }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #473 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- Resumable 클래스에서 구현하던 상호 배제 방식을 NSLock 기반에서 Swift Actor로 마이그레이션하여 더 안전한 동시성 처리를 구현했습니다.
- unsafeContinuation은 적용하지 않았습니다! 변경함으로써 발생할 수 있는 사이드 이펙트가 기대하는 성능 향상에 비해 위험도가 높다고 판단했습니다. 추후 해당 부분에서 성능 이슈가 발생하면 변경하는 것이 좋을 것 같습니다 ~! 

### 변경한 이유
**컴파일 타임 안전성**
Actor가 컴파일러 레벨에서 데이터 레이스 방지
isResumed 상태에 대한 안전한 접근 보장

**코드 간결성**
수동 lock/unlock 코드 제거 (각 메서드에서 2줄 제거)
보일러플레이트 코드 제거로 가독성 향상

**데드락 방지**
actor는 suspension point에서 스레드를 양보하기 때문에 NSLock을 사용할 때 발생할 수 있는 데드락 해결

**Swift Concurrency 통합**
async/await 패턴과 자연스럽게 통합

**actor의 재진입으로 인한 상태 불일치 해소**
resume 전에 상태 재검증으로 상태 불일치 가능성 해소

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`SocialLoginService`
- before
```swift
final class Resumable {
    private var isResumed = false
    private let lock = NSLock()
    private let continuation: CheckedContinuation<String, Error>
    
    func resume(throwing: Error) {
        lock.lock()
        defer { lock.unlock() }
        
        guard !isResumed else { return }
        isResumed = true
        continuation.resume(throwing: throwing)
    }
    
    func resume(returning: String) {
        lock.lock()
        defer { lock.unlock() }
        
        guard !isResumed else { return }
        isResumed = true
        continuation.resume(returning: returning)
    }
}
```

- after
```swift
actor Resumable {
    private var isResumed = false
    private let continuation: CheckedContinuation<String, Error>
    
    func resume(throwing error: Error) {
        guard !isResumed else { return }
        isResumed = true
        continuation.resume(throwing: error)
    }
    
    func resume(returning value: String) {
        guard !isResumed else { return }
        isResumed = true
        continuation.resume(returning: value)
    }
}
```
